### PR TITLE
Add `provides=linux` to asahi-linux

### DIFF
--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -69,7 +69,7 @@ _package() {
   depends=(coreutils kmod initramfs)
   optdepends=('crda: to set the correct wireless channels of your country'
               'linux-firmware: firmware images needed for some devices')
-  provides=(WIREGUARD-MODULE)
+  provides=(WIREGUARD-MODULE linux=${pkgver})
   replaces=(wireguard-arch)
 
   cd $_srcname


### PR DESCRIPTION
Packages that have a dependency on `linux` fail to install since they
have an unmet dependency. This makes the asahi-linux package satisfy
said dependency.