### PR TITLE
fix variable in cleanup of other architectures, which led to external…

### DIFF
--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -142,7 +142,7 @@ _package-headers() {
   echo "Removing unneeded architectures..."
   local arch
   for arch in "$builddir"/arch/*/; do
-    [[ $arch = */{KARCH}/ ]] && continue
+    [[ $arch = */${KARCH}/ ]] && continue
     echo "Removing $(basename "$arch")"
     rm -r "$arch"
   done


### PR DESCRIPTION
while removing unneeded architectures, we had a small typo that led the script to delete all architectures (including KARCH).

this broke building of kernel modules (evdi), becoause they couldn't find the directory. 

