### PR TITLE
A few fixes for the PKGBUILDs

### DIFF
--- a/asahi-desktop-meta/PKGBUILD
+++ b/asahi-desktop-meta/PKGBUILD
@@ -8,8 +8,10 @@ url='https://www.asahilinux.org'
 arch=('any')
 license=('MIT')
 install=asahi-desktop-meta.install
-depends=(bluedevil bluez-utils pulseaudio-bluetooth bluez-tools)
+
+package() {
+  # Put depends in package() to avoid unecessary build dependencies
+  depends=(bluedevil bluez-utils pulseaudio-bluetooth bluez-tools)
+}
 
 # vim: ts=2 sw=2 et:
-
-

--- a/asahi-fwextract/PKGBUILD
+++ b/asahi-fwextract/PKGBUILD
@@ -13,7 +13,7 @@ install=asahi-fwextract.install
 sha256sums=('05985db69cfbd1f65f8e0c61545fa28f9e0d04d7d1278e3c8686c36a19a72e6c')
 b2sums=('f67d1de0413258c04a57d455db5edcf6a586fe191418f7b1d7d4616734b3d1ad4dfaa1db1261c420854e7b6cbdb8fe8edfe1cc353277435b6ea2a51f7aa893b1')
 depends=(python asahi-scripts)
-makedepends=(python-build python-installer python-wheel)
+makedepends=(python-build python-installer python-wheel python-setuptools)
 
 build() {
     cd "$_name-$pkgver"

--- a/asahi-meta/PKGBUILD
+++ b/asahi-meta/PKGBUILD
@@ -7,10 +7,12 @@ pkgdesc='Asahi Linux core support meta package'
 url='https://www.asahilinux.org'
 arch=('any')
 license=('MIT')
-depends=(
-  'linux-asahi' 'uboot-asahi' 'm1n1' 'asahi-scripts' 'asahilinux-keyring' 'asahi-fwextract'
-)
+
+package() {
+  # Put depends in package() to avoid unecessary build dependencies
+  depends=(
+    'linux-asahi' 'uboot-asahi' 'm1n1' 'asahi-scripts' 'asahilinux-keyring' 'asahi-fwextract'
+  )
+}
 
 # vim: ts=2 sw=2 et:
-
-


### PR DESCRIPTION
* For meta packages, the dependencies are only needed at installation time and not at build time. Moving them to the package function makes it easier to build such packages.
* asahi-fwextract has missing dependency, noticed during chroot build of the package. https://buildarm.archlinuxcn.org/imlonghao-api/pkg/asahi-fwextract/log/1657992036

I could split this to multiple PRs if necessary but I feel like these are small enough changes that I hope it doesn't matter that much...