### PR TITLE
Add qt5-webengine and qt6-webengine with chromium page size fix

### DIFF
--- a/qt5-webengine/0001-ARM-toolchain-fixes.patch
+++ b/qt5-webengine/0001-ARM-toolchain-fixes.patch
@@ -1,0 +1,58 @@
+From 831eeefaebc489ecb64f945cfa62f79771be3bf5 Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Tue, 4 Jul 2017 11:54:39 -0600
+Subject: [PATCH 1/4] ARM toolchain fixes
+
+---
+ chromium/build/toolchain/linux/BUILD.gn | 24 ++++++++++--------------
+ 1 file changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/chromium/build/toolchain/linux/BUILD.gn b/chromium/build/toolchain/linux/BUILD.gn
+index fa8b17e9db3..7398b7556ec 100644
+--- a/chromium/build/toolchain/linux/BUILD.gn
++++ b/chromium/build/toolchain/linux/BUILD.gn
+@@ -30,15 +30,13 @@ clang_toolchain("clang_arm64") {
+ }
+ 
+ gcc_toolchain("arm64") {
+-  toolprefix = "aarch64-linux-gnu-"
+-
+-  cc = "${toolprefix}gcc"
+-  cxx = "${toolprefix}g++"
++  cc = "gcc"
++  cxx = "g++"
+ 
+-  ar = "${toolprefix}ar"
++  ar = "ar"
+   ld = cxx
+-  readelf = "${toolprefix}readelf"
+-  nm = "${toolprefix}nm"
++  readelf = "readelf"
++  nm = "nm"
+ 
+   toolchain_args = {
+     current_cpu = "arm64"
+@@ -48,15 +46,13 @@ gcc_toolchain("arm64") {
+ }
+ 
+ gcc_toolchain("arm") {
+-  toolprefix = "arm-linux-gnueabihf-"
+-
+-  cc = "${toolprefix}gcc"
+-  cxx = "${toolprefix}g++"
++  cc = "gcc"
++  cxx = "g++"
+ 
+-  ar = "${toolprefix}ar"
++  ar = "ar"
+   ld = cxx
+-  readelf = "${toolprefix}readelf"
+-  nm = "${toolprefix}nm"
++  readelf = "readelf"
++  nm = "nm"
+ 
+   toolchain_args = {
+     current_cpu = "arm"
+-- 
+2.33.0
+

--- a/qt5-webengine/0002-Fix-ARM-skia-ICE.patch
+++ b/qt5-webengine/0002-Fix-ARM-skia-ICE.patch
@@ -1,0 +1,25 @@
+From 895dec8c2d626f176cb85af81c09c7bf30e2ad43 Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Mon, 1 Jul 2019 07:10:36 -0600
+Subject: [PATCH 2/4] Fix ARM skia ICE
+
+---
+ chromium/third_party/skia/third_party/skcms/src/Transform_inl.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chromium/third_party/skia/third_party/skcms/src/Transform_inl.h b/chromium/third_party/skia/third_party/skcms/src/Transform_inl.h
+index 2dcf717f3b7..8e1acb01fee 100644
+--- a/chromium/third_party/skia/third_party/skcms/src/Transform_inl.h
++++ b/chromium/third_party/skia/third_party/skcms/src/Transform_inl.h
+@@ -687,7 +687,7 @@ SI void sample_clut_16(const skcms_A2B* a2b, I32 ix, F* r, F* g, F* b) {
+ // GCC 7.2.0 hits an internal compiler error with -finline-functions (or -O3)
+ // when targeting MIPS 64, i386, or s390x,  I think attempting to inline clut() into exec_ops().
+ #if 1 && defined(__GNUC__) && !defined(__clang__) \
+-      && (defined(__mips64) || defined(__i386) || defined(__s390x__))
++      && (defined(__mips64) || defined(__i386) || defined(__s390x__) || defined(__arm__))
+     #define MAYBE_NOINLINE __attribute__((noinline))
+ #else
+     #define MAYBE_NOINLINE
+-- 
+2.33.0
+

--- a/qt5-webengine/0003-bind-gen-Support-single_process-flag-in-generate_bin.patch
+++ b/qt5-webengine/0003-bind-gen-Support-single_process-flag-in-generate_bin.patch
@@ -1,0 +1,157 @@
+From a3a795afdd386242fa115309c5fd349b0095bfdd Mon Sep 17 00:00:00 2001
+From: Yuki Shiino <yukishiino@chromium.org>
+Date: Mon, 5 Oct 2020 11:01:57 +0000
+Subject: [PATCH 3/4] bind-gen: Support --single_process flag in
+ generate_bindings.py
+
+Error messages of generate_bindings.py are often hard to read
+due to multiprocessing.  Supports --single_process flag for
+debugging purpose.
+
+Bug: 839389
+Change-Id: Ibe0d55716cdc9d5db77b0714dd96c11832ab0143
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/2447529
+Reviewed-by: Hitoshi Yoshida <peria@chromium.org>
+Commit-Queue: Yuki Shiino <yukishiino@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#813675}
+---
+ .../bindings/scripts/bind_gen/task_queue.py   | 74 +++++++++++--------
+ .../bindings/scripts/generate_bindings.py     |  8 +-
+ 2 files changed, 49 insertions(+), 33 deletions(-)
+
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
+index e666a9b668e..42b96d41688 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
+@@ -14,10 +14,23 @@ class TaskQueue(object):
+     tasks will be executed in parallel.
+     """
+ 
+-    def __init__(self):
+-        self._pool_size = multiprocessing.cpu_count()
+-        self._pool = multiprocessing.Pool(self._pool_size,
+-                                          package_initializer().init)
++    def __init__(self, single_process=False):
++        """
++        Args:
++            single_process: True makes the instance will not create nor use a
++                child process so that error messages will be easier to read.
++                This is useful for debugging.
++        """
++        assert isinstance(single_process, bool)
++        if single_process:
++            self._single_process = True
++            self._pool_size = 1
++            self._pool = None
++        else:
++            self._single_process = False
++            self._pool_size = multiprocessing.cpu_count()
++            self._pool = multiprocessing.Pool(self._pool_size,
++                                              package_initializer().init)
+         self._requested_tasks = []  # List of (func, args, kwargs)
+         self._worker_tasks = []  # List of multiprocessing.pool.AsyncResult
+         self._did_run = False
+@@ -37,28 +50,42 @@ class TaskQueue(object):
+         Args:
+             report_progress: A callable that takes two arguments, total number
+                 of worker tasks and number of completed worker tasks.
+-                Scheduled tasks are reorganized into worker tasks, so the
+-                number of worker tasks may be different from the number of
+-                scheduled tasks.
+         """
+         assert report_progress is None or callable(report_progress)
+         assert not self._did_run
+         assert not self._worker_tasks
+         self._did_run = True
+ 
+-        num_of_requested_tasks = len(self._requested_tasks)
+-        chunk_size = 1
+-        i = 0
+-        while i < num_of_requested_tasks:
+-            tasks = self._requested_tasks[i:i + chunk_size]
+-            i += chunk_size
++        if self._single_process:
++            self._run_in_sequence(report_progress)
++        else:
++            self._run_in_parallel(report_progress)
++
++    def _run_in_sequence(self, report_progress):
++        for index, task in enumerate(self._requested_tasks):
++            func, args, kwargs = task
++            report_progress(len(self._requested_tasks), index)
++            func(*args, **kwargs)
++        report_progress(len(self._requested_tasks), len(self._requested_tasks))
++
++    def _run_in_parallel(self, report_progress):
++        for task in self._requested_tasks:
++            func, args, kwargs = task
+             self._worker_tasks.append(
+-                self._pool.apply_async(_task_queue_run_tasks, [tasks]))
++                self._pool.apply_async(func, args, kwargs))
+         self._pool.close()
+ 
++        def report_worker_task_progress():
++            if not report_progress:
++                return
++            done_count = functools.reduce(
++                lambda count, worker_task: count + bool(worker_task.ready()),
++                self._worker_tasks, 0)
++            report_progress(len(self._worker_tasks), done_count)
++
+         timeout_in_sec = 1
+         while True:
+-            self._report_worker_task_progress(report_progress)
++            report_worker_task_progress()
+             for worker_task in self._worker_tasks:
+                 if not worker_task.ready():
+                     worker_task.wait(timeout_in_sec)
+@@ -70,20 +97,3 @@ class TaskQueue(object):
+                 break
+ 
+         self._pool.join()
+-
+-    def _report_worker_task_progress(self, report_progress):
+-        assert report_progress is None or callable(report_progress)
+-
+-        if not report_progress:
+-            return
+-
+-        done_count = functools.reduce(
+-            lambda count, worker_task: count + bool(worker_task.ready()),
+-            self._worker_tasks, 0)
+-        report_progress(len(self._worker_tasks), done_count)
+-
+-
+-def _task_queue_run_tasks(tasks):
+-    for task in tasks:
+-        func, args, kwargs = task
+-        func(*args, **kwargs)
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/generate_bindings.py b/chromium/third_party/blink/renderer/bindings/scripts/generate_bindings.py
+index 96a9ebccdbf..528d1b2f61d 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/generate_bindings.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/generate_bindings.py
+@@ -37,6 +37,12 @@ def parse_options():
+         type="string",
+         help='output directory for "modules" component relative '
+         'to root_gen_dir')
++    parser.add_option(
++        '--single_process',
++        action="store_true",
++        default=False,
++        help=('run everything in a single process, which makes debugging '
++              'easier'))
+     options, args = parser.parse_args()
+ 
+     required_option_names = ("web_idl_database", "root_src_dir",
+@@ -76,7 +82,7 @@ def main():
+                   root_gen_dir=options.root_gen_dir,
+                   component_reldirs=component_reldirs)
+ 
+-    task_queue = bind_gen.TaskQueue()
++    task_queue = bind_gen.TaskQueue(single_process=options.single_process)
+ 
+     for task in tasks:
+         dispatch_table[task](task_queue)
+-- 
+2.33.0
+

--- a/qt5-webengine/0004-Run-blink-bindings-generation-single-threaded.patch
+++ b/qt5-webengine/0004-Run-blink-bindings-generation-single-threaded.patch
@@ -1,0 +1,25 @@
+From 67b6ede8c7b82dfddc53b945945a5d4c9e2ad9c3 Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Tue, 2 Feb 2021 13:58:59 -0700
+Subject: [PATCH 4/4] Run blink bindings generation single threaded
+
+When not single threaded this process will eat all the RAM.
+---
+ chromium/third_party/blink/renderer/bindings/BUILD.gn | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chromium/third_party/blink/renderer/bindings/BUILD.gn b/chromium/third_party/blink/renderer/bindings/BUILD.gn
+index 6a457ced15a..09f1250d173 100644
+--- a/chromium/third_party/blink/renderer/bindings/BUILD.gn
++++ b/chromium/third_party/blink/renderer/bindings/BUILD.gn
+@@ -181,6 +181,7 @@ template("generate_bindings") {
+     outputs = invoker.outputs
+ 
+     args = [
++             "--single_process",
+              "--web_idl_database",
+              rebase_path(web_idl_database, root_build_dir),
+              "--root_src_dir",
+-- 
+2.33.0
+

--- a/qt5-webengine/PKGBUILD
+++ b/qt5-webengine/PKGBUILD
@@ -1,0 +1,108 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Contributor: Andrea Scarpino <andrea@archlinux.org>
+
+# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+#  - patch for chromium GN
+#  - patch for chromium skia
+#  - patch for chromium to run blink bindings generation single threaded
+#  - build v7 with -j4
+
+highmem=1
+
+pkgname=qt5-webengine
+_basever=5.15.5
+pkgver=5.15.10
+pkgrel=3
+arch=('x86_64')
+url='https://www.qt.io'
+license=('LGPL3' 'LGPL2.1' 'BSD')
+pkgdesc='Provides support for web applications using the Chromium browser project'
+depends=('qt5-webchannel' 'qt5-location' 'libxcomposite' 'libxrandr' 'pciutils' 'libxss' 'libxkbfile' 
+         'libevent' 'snappy' 'nss' 'libxslt' 'minizip' 'ffmpeg' 're2' 'libvpx' 'libxtst' 'ttf-font')
+makedepends=('git' 'python' 'gperf' 'jsoncpp' 'ninja' 'qt5-tools' 'poppler' 'pipewire' 'nodejs')
+optdepends=('pipewire: WebRTC desktop sharing under Wayland')
+groups=('qt' 'qt5')
+_pkgfqn=${pkgname/5-/}
+source=(git+https://code.qt.io/qt/qtwebengine.git#tag=v${pkgver}-lts
+        git+https://code.qt.io/qt/qtwebengine-chromium.git
+        git+https://chromium.googlesource.com/catapult#commit=5eedfe23148a234211ba477f76fc2ea2e8529189
+        qt5-webengine-python3.patch
+        qt5-webengine-chromium-python3.patch
+        qt5-webengine-ffmpeg5.patch
+        qt5-webengine-pipewire-0.3.patch
+        qt5-webengine-gcc12.patch
+        0001-ARM-toolchain-fixes.patch
+        0002-Fix-ARM-skia-ICE.patch
+        0003-bind-gen-Support-single_process-flag-in-generate_bin.patch
+        0004-Run-blink-bindings-generation-single-threaded.patch
+        qt5-webengine-16kpage.patch)
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            '398c996cb5b606695ac93645143df39e23fa67e768b09e0da6dbd37342a43f32'
+            'fda4ff16790799fb285847918a677f4f3f7c0f513d4751f846ffc5aa5d873932'
+            'c50d3019626183e753c53a997dc8a55938847543aa3178d4c51f377be741c693'
+            '5e3a3c4711d964d5152a04059a2b5c1d14bb13dd29bce370120f60e85b476b6f'
+            'cf9be3ffcc3b3cd9450b1ff13535ff7d76284f73173412d097a6ab487463a379'
+            '81b7a62368f40d757b165b88df4813413f30db797e4f93a84dd75e12e1ebd679'
+            '298037fcbc132f1539616cdf6149ad5da104f8e2345a9c1af1e7bf8b0dd52c70'
+            'b878770648437c9bc24023b1d5a47bcd51382d7142b695864c3379826511bcd9'
+            'e447f5d2635f8f32914c912d7f99b38726c1541334f3a2c1a8ca2dbde565a7de'
+            '69e4899c8c5b08b3bd263f21970a970eb362b2b78b0244fb9c9350494fa0a982')
+options=(debug)
+
+prepare() {
+  mkdir -p build
+
+  cd ${_pkgfqn}
+  git submodule init
+  git submodule set-url src/3rdparty "$srcdir"/qtwebengine-chromium
+  git submodule set-branch --branch 87-based src/3rdparty
+  git submodule update
+
+  patch -p1 -i "$srcdir"/qt5-webengine-python3.patch # Fix build with Python 3
+  patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-chromium-python3.patch
+
+  patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-ffmpeg5.patch # Fix build with ffmpeg 5
+  patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-pipewire-0.3.patch # Port to pipewire 0.3
+  patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-gcc12.patch # Fix build with GCC 12
+
+# Update catapult for python3 compatibility
+  rm -r src/3rdparty/chromium/third_party/catapult
+  mv "$srcdir"/catapult src/3rdparty/chromium/third_party
+
+  [[ $CARCH == "armv7h" ]] && export NINJAJOBS="-j4"
+  cd "$srcdir/$_pkgfqn/src/3rdparty"
+  patch -p1 -i ${srcdir}/0001-ARM-toolchain-fixes.patch
+  patch -p1 -i ${srcdir}/0002-Fix-ARM-skia-ICE.patch
+  patch -p1 -i ${srcdir}/0003-bind-gen-Support-single_process-flag-in-generate_bin.patch
+  patch -p1 -i ${srcdir}/0004-Run-blink-bindings-generation-single-threaded.patch
+  patch -p1 -i ${srcdir}/qt5-webengine-16kpage.patch
+}
+
+build() {
+  cd build
+  qmake ../${_pkgfqn} CONFIG+=force_debug_info -- \
+    -proprietary-codecs \
+    -system-ffmpeg \
+    -webp \
+    -spellchecker \
+    -webengine-icu \
+    -webengine-kerberos \
+    -webengine-webrtc-pipewire
+  make
+}
+
+package() {
+  cd build
+  make INSTALL_ROOT="$pkgdir" install
+
+  # Drop QMAKE_PRL_BUILD_DIR because reference the build dir
+  find "$pkgdir/usr/lib" -type f -name '*.prl' \
+    -exec sed -i -e '/^QMAKE_PRL_BUILD_DIR/d' {} \;
+
+  install -Dm644 "$srcdir"/${_pkgfqn}/src/3rdparty/chromium/LICENSE "$pkgdir"/usr/share/licenses/${pkgname}/LICENSE.chromium
+
+  # Fix cmake dependency versions
+  sed -e "s|$pkgver\ |$_basever |" -i "$pkgdir"/usr/lib/cmake/*/*Config.cmake
+}

--- a/qt5-webengine/chromium-harfbuzz-3.0.0.patch
+++ b/qt5-webengine/chromium-harfbuzz-3.0.0.patch
@@ -1,0 +1,20 @@
+# https://github.com/chromium/chromium/commit/b289f6f3fcbc
+
+diff --git a/components/paint_preview/common/subset_font.cc b/components/paint_preview/common/subset_font.cc
+index 8ff0540d9a..20a7d37474 100644
+--- a/components/paint_preview/common/subset_font.cc
++++ b/components/paint_preview/common/subset_font.cc
+@@ -72,9 +72,11 @@ sk_sp<SkData> SubsetFont(SkTypeface* typeface, const GlyphUsage& usage) {
+   hb_set_t* glyphs =
+       hb_subset_input_glyph_set(input.get());  // Owned by |input|.
+   usage.ForEach(base::BindRepeating(&AddGlyphs, base::Unretained(glyphs)));
+-  hb_subset_input_set_retain_gids(input.get(), true);
++  hb_subset_input_set_flags(input.get(), HB_SUBSET_FLAGS_RETAIN_GIDS);
+ 
+-  HbScoped<hb_face_t> subset_face(hb_subset(face.get(), input.get()));
++  HbScoped<hb_face_t> subset_face(hb_subset_or_fail(face.get(), input.get()));
++  if (!subset_face)
++    return nullptr;
+   HbScoped<hb_blob_t> subset_blob(hb_face_reference_blob(subset_face.get()));
+   if (!subset_blob)
+     return nullptr;

--- a/qt5-webengine/qt5-webengine-16kpage.patch
+++ b/qt5-webengine/qt5-webengine-16kpage.patch
@@ -1,0 +1,345 @@
+From 938a63687384250278b55e8c2e8d4216e6437fba Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Tue, 19 Jul 2022 23:58:46 -0400
+Subject: [PATCH] Backport of 16k page support on aarch64
+
+---
+ .../address_space_randomization.h             | 15 ++++++
+ .../page_allocator_constants.h                | 51 +++++++++++++++++-
+ .../partition_address_space.cc                |  6 +++
+ .../partition_allocator/partition_alloc.cc    |  2 +-
+ .../partition_alloc_constants.h               |  5 +-
+ .../address_space_randomization.h             | 15 ++++++
+ .../partition_allocator/page_allocator.cc     |  8 +++
+ .../page_allocator_constants.h                | 52 ++++++++++++++++++-
+ .../partition_allocator/partition_alloc.cc    |  2 +-
+ .../partition_alloc_constants.h               |  5 +-
+ 10 files changed, 153 insertions(+), 8 deletions(-)
+
+diff --git a/chromium/base/allocator/partition_allocator/address_space_randomization.h b/chromium/base/allocator/partition_allocator/address_space_randomization.h
+index e77003eab25..31ac05b86f5 100644
+--- a/chromium/base/allocator/partition_allocator/address_space_randomization.h
++++ b/chromium/base/allocator/partition_allocator/address_space_randomization.h
+@@ -119,6 +119,21 @@ AslrMask(uintptr_t bits) {
+         return AslrAddress(0x20000000ULL);
+       }
+ 
++      #elif defined(OS_LINUX)
++
++      // Linux on arm64 can use 39, 42, 48, or 52-bit user space, depending on
++      // page size and number of levels of translation pages used. We use
++      // 39-bit as base as all setups should support this, lowered to 38-bit
++      // as ASLROffset() could cause a carry.
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLRMask() {
++        return AslrMask(38);
++      }
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLROffset() {
++        return AslrAddress(0x1000000000ULL);
++      }
++
+       #else
+ 
+       // ARM64 on Linux has 39-bit user space. Use 38 bits since ASLROffset()
+diff --git a/chromium/base/allocator/partition_allocator/page_allocator_constants.h b/chromium/base/allocator/partition_allocator/page_allocator_constants.h
+index c42fe2835ff..dc7486608b9 100644
+--- a/chromium/base/allocator/partition_allocator/page_allocator_constants.h
++++ b/chromium/base/allocator/partition_allocator/page_allocator_constants.h
+@@ -24,6 +24,31 @@
+ // elimination.
+ #define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
+ 
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++// This should work for all POSIX (if needed), but currently all other
++// supported OS/architecture combinations use either hard-coded values
++// (such as x86) or have means to determine these values without needing
++// atomics (such as macOS on arm64).
++
++// Page allocator constants are run-time constant
++#define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
++
++#include <unistd.h>
++#include <atomic>
++
++namespace base::internal {
++
++// Holds the current page size and shift, where size = 1 << shift
++// Use PageAllocationGranularity(), PageAllocationGranularityShift()
++// to initialize and retrieve these values safely.
++struct PageCharacteristics {
++  std::atomic<int> size;
++  std::atomic<int> shift;
++};
++extern PageCharacteristics page_characteristics;
++
++}  // namespace base::internal
++
+ #else
+ 
+ // When defined, page size constants are fixed at compile time. When not
+@@ -36,11 +61,17 @@
+ 
+ #endif
+ 
++namespace base {
++// Forward declaration, implementation below
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
++PageAllocationGranularity();
++}
++
+ namespace {
+ 
+ #if !defined(OS_APPLE)
+ 
+-constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int PageAllocationGranularityShift() {
+ #if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+   // Modern ppc64 systems support 4kB (shift = 12) and 64kB (shift = 16) page
+   // sizes.  Since 64kB is the de facto standard on the platform and binaries
+@@ -49,6 +80,15 @@ constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
+   return 16;  // 64kB
+ #elif defined(_MIPS_ARCH_LOONGSON)
+   return 14;  // 16kB
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb (shift = 12), 16kb (shift = 14), and 64kb (shift = 16)
++  // page sizes. Retrieve from or initialize cache.
++  int shift = base::internal::page_characteristics.shift.load(std::memory_order_relaxed);
++  if (UNLIKELY(shift == 0)) {
++    shift = __builtin_ctz((int)base::PageAllocationGranularity());
++    base::internal::page_characteristics.shift.store(shift, std::memory_order_relaxed);
++  }
++  return shift;
+ #else
+   return 12;  // 4kB
+ #endif
+@@ -64,6 +104,15 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PageAllocationGranularity() {
+ #if defined(OS_APPLE)
+   return vm_page_size;
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb, 16kb, and 64kb page sizes. Retrieve from or
++  // initialize cache.
++  int size = internal::page_characteristics.size.load(std::memory_order_relaxed);
++  if (UNLIKELY(size == 0)) {
++    size = getpagesize();
++    internal::page_characteristics.size.store(size, std::memory_order_relaxed);
++  }
++  return size;
+ #else
+   return 1ULL << PageAllocationGranularityShift();
+ #endif
+diff --git a/chromium/base/allocator/partition_allocator/partition_address_space.cc b/chromium/base/allocator/partition_allocator/partition_address_space.cc
+index 03883bcb113..90efc51c838 100644
+--- a/chromium/base/allocator/partition_allocator/partition_address_space.cc
++++ b/chromium/base/allocator/partition_allocator/partition_address_space.cc
+@@ -75,6 +75,12 @@ void PartitionAddressSpace::UninitForTesting() {
+   internal::AddressPoolManager::GetInstance()->ResetForTesting();
+ }
+ 
++#if defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
++PageCharacteristics page_characteristics;
++
++#endif  // defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
+ #endif  // defined(PA_HAS_64_BITS_POINTERS)
+ 
+ }  // namespace internal
+diff --git a/chromium/base/allocator/partition_allocator/partition_alloc.cc b/chromium/base/allocator/partition_allocator/partition_alloc.cc
+index daeb6d5cb17..7c434b5e697 100644
+--- a/chromium/base/allocator/partition_allocator/partition_alloc.cc
++++ b/chromium/base/allocator/partition_allocator/partition_alloc.cc
+@@ -522,7 +522,7 @@ static size_t PartitionPurgePage(internal::PartitionPage<thread_safe>* page,
+ #if defined(PAGE_ALLOCATOR_CONSTANTS_ARE_CONSTEXPR)
+   constexpr size_t kMaxSlotCount =
+       (PartitionPageSize() * kMaxPartitionPagesPerSlotSpan) / SystemPageSize();
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+   // It's better for slot_usage to be stack-allocated and fixed-size, which
+   // demands that its size be constexpr. On OS_APPLE, PartitionPageSize() is
+   // always SystemPageSize() << 2, so regardless of what the run time page size
+diff --git a/chromium/base/allocator/partition_allocator/partition_alloc_constants.h b/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
+index c8268ec30a0..f03ba1e4ab4 100644
+--- a/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
++++ b/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
+@@ -57,10 +57,11 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+   return 18;  // 256 KiB
+ }
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || \
++    (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+-  return vm_page_shift + 2;
++  return PageAllocationGranularityShift() + 2;
+ }
+ #else
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
+index 28c8271fd68..3957e0cdf76 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
+@@ -120,6 +120,21 @@ AslrMask(uintptr_t bits) {
+         return AslrAddress(0x20000000ULL);
+       }
+ 
++      #elif defined(OS_LINUX)
++
++      // Linux on arm64 can use 39, 42, 48, or 52-bit user space, depending on
++      // page size and number of levels of translation pages used. We use
++      // 39-bit as base as all setups should support this, lowered to 38-bit
++      // as ASLROffset() could cause a carry.
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLRMask() {
++        return AslrMask(38);
++      }
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLROffset() {
++        return AslrAddress(0x1000000000ULL);
++      }
++
+       #else
+ 
+       // ARM64 on Linux has 39-bit user space. Use 38 bits since kASLROffset
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
+index 91d00d2fbca..597d5f84cb1 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
+@@ -255,5 +255,13 @@ uint32_t GetAllocPageErrorCode() {
+   return s_allocPageErrorCode;
+ }
+ 
++#if defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
++namespace internal {
++PageCharacteristics page_characteristics;
++}
++
++#endif  // defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
+ }  // namespace base
+ }  // namespace pdfium
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
+index fdc65ac47b7..f826308839d 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
+@@ -24,6 +24,31 @@
+ // elimination.
+ #define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
+ 
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++// This should work for all POSIX (if needed), but currently all other
++// supported OS/architecture combinations use either hard-coded values
++// (such as x86) or have means to determine these values without needing
++// atomics (such as macOS on arm64).
++
++// Page allocator constants are run-time constant
++#define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
++
++#include <unistd.h>
++#include <atomic>
++
++namespace pdfium::base::internal {
++
++// Holds the current page size and shift, where size = 1 << shift
++// Use PageAllocationGranularity(), PageAllocationGranularityShift()
++// to initialize and retrieve these values safely.
++struct PageCharacteristics {
++  std::atomic<int> size;
++  std::atomic<int> shift;
++};
++extern PageCharacteristics page_characteristics;
++
++}  // namespace base::internal
++
+ #else
+ 
+ // When defined, page size constants are fixed at compile time. When not
+@@ -37,11 +62,18 @@
+ #endif
+ 
+ namespace pdfium {
++
++namespace base {
++// Forward declaration, implementation below
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
++PageAllocationGranularity();
++}
++
+ namespace {
+ 
+ #if !defined(OS_APPLE)
+ 
+-constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int PageAllocationGranularityShift() {
+ #if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+   // Modern ppc64 systems support 4kB (shift = 12) and 64kB (shift = 16) page
+   // sizes.  Since 64kB is the de facto standard on the platform and binaries
+@@ -50,6 +82,15 @@ constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
+   return 16;  // 64kB
+ #elif defined(_MIPS_ARCH_LOONGSON)
+   return 14;  // 16kB
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb (shift = 12), 16kb (shift = 14), and 64kb (shift = 16)
++  // page sizes. Retrieve from or initialize cache.
++  int shift = base::internal::page_characteristics.shift.load(std::memory_order_relaxed);
++  if (UNLIKELY(shift == 0)) {
++    shift = __builtin_ctz((int)base::PageAllocationGranularity());
++    base::internal::page_characteristics.shift.store(shift, std::memory_order_relaxed);
++  }
++  return shift;
+ #else
+   return 12;  // 4kB
+ #endif
+@@ -65,6 +106,15 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PageAllocationGranularity() {
+ #if defined(OS_APPLE)
+   return vm_page_size;
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb, 16kb, and 64kb page sizes. Retrieve from or
++  // initialize cache.
++  int size = internal::page_characteristics.size.load(std::memory_order_relaxed);
++  if (UNLIKELY(size == 0)) {
++    size = getpagesize();
++    internal::page_characteristics.size.store(size, std::memory_order_relaxed);
++  }
++  return size;
+ #else
+   return 1ULL << PageAllocationGranularityShift();
+ #endif
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
+index 2e5e87fa7e6..89b9f6217a6 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
+@@ -486,7 +486,7 @@ static size_t PartitionPurgePage(internal::PartitionPage* page, bool discard) {
+ #if defined(PAGE_ALLOCATOR_CONSTANTS_ARE_CONSTEXPR)
+   constexpr size_t kMaxSlotCount =
+       (PartitionPageSize() * kMaxPartitionPagesPerSlotSpan) / SystemPageSize();
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+   // It's better for slot_usage to be stack-allocated and fixed-size, which
+   // demands that its size be constexpr. On OS_APPLE, PartitionPageSize() is
+   // always SystemPageSize() << 2, so regardless of what the run time page size
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
+index 71d63ba4146..a6d83626741 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
+@@ -50,10 +50,11 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+   return 18;  // 256 KiB
+ }
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || \
++    (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+-  return vm_page_shift + 2;
++  return PageAllocationGranularityShift() + 2;
+ }
+ #else
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+-- 
+2.37.1
+

--- a/qt5-webengine/qt5-webengine-chromium-python3.patch
+++ b/qt5-webengine/qt5-webengine-chromium-python3.patch
@@ -1,0 +1,1812 @@
+diff --git a/chromium/build/print_python_deps.py b/chromium/build/print_python_deps.py
+index fd29c0972c9..69af247094b 100755
+--- a/chromium/build/print_python_deps.py
++++ b/chromium/build/print_python_deps.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python2.7
++#!/usr/bin/python
+ # Copyright 2016 The Chromium Authors. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+@@ -80,7 +80,7 @@ def _GetTargetPythonVersion(module):
+   if shebang.startswith('#!'):
+     # Examples:
+     # '#!/usr/bin/python'
+-    # '#!/usr/bin/python2.7'
++    # '#!/usr/bin/python'
+     # '#!/usr/bin/python3'
+     # '#!/usr/bin/env python3'
+     # '#!/usr/bin/env vpython'
+@@ -152,7 +152,7 @@ def main():
+ 
+   # Trybots run with vpython as default Python, but with a different config
+   # from //.vpython. To make the is_vpython test work, and to match the behavior
+-  # of dev machines, the shebang line must be run with python2.7.
++  # of dev machines, the shebang line must be run with python.
+   #
+   # E.g. $HOME/.vpython-root/dd50d3/bin/python
+   # E.g. /b/s/w/ir/cache/vpython/ab5c79/bin/python
+diff --git a/chromium/components/resources/protobufs/binary_proto_generator.py b/chromium/components/resources/protobufs/binary_proto_generator.py
+index 7422ead9697..16365515f26 100755
+--- a/chromium/components/resources/protobufs/binary_proto_generator.py
++++ b/chromium/components/resources/protobufs/binary_proto_generator.py
+@@ -7,7 +7,7 @@
+  Converts a given ASCII proto into a binary resource.
+ 
+ """
+-
++from __future__ import print_function
+ import abc
+ import imp
+ import optparse
+@@ -196,12 +196,12 @@ class BinaryProtoGenerator:
+     self._ImportProtoModules(opts.path)
+ 
+     if not self.VerifyArgs(opts):
+-      print "Wrong arguments"
++      print("Wrong arguments")
+       return 1
+ 
+     try:
+       self._GenerateBinaryProtos(opts)
+     except Exception as e:
+-      print "ERROR: Failed to render binary version of %s:\n  %s\n%s" % (
+-          opts.infile, str(e), traceback.format_exc())
++      print("ERROR: Failed to render binary version of %s:\n  %s\n%s" %
++            (opts.infile, str(e), traceback.format_exc()))
+       return 1
+diff --git a/chromium/content/browser/tracing/generate_trace_viewer_grd.py b/chromium/content/browser/tracing/generate_trace_viewer_grd.py
+index 037f9497dc2..be393d21f90 100755
+--- a/chromium/content/browser/tracing/generate_trace_viewer_grd.py
++++ b/chromium/content/browser/tracing/generate_trace_viewer_grd.py
+@@ -74,7 +74,7 @@ def main(argv):
+   for filename in parsed_args.source_files:
+     add_file_to_grd(doc, os.path.basename(filename))
+ 
+-  with open(parsed_args.output_filename, 'w') as output_file:
++  with open(parsed_args.output_filename, 'wb') as output_file:
+     output_file.write(doc.toxml(encoding='UTF-8'))
+ 
+ 
+diff --git a/chromium/mojo/public/tools/bindings/BUILD.gn b/chromium/mojo/public/tools/bindings/BUILD.gn
+index fc04b5dd0b1..708958e438b 100644
+--- a/chromium/mojo/public/tools/bindings/BUILD.gn
++++ b/chromium/mojo/public/tools/bindings/BUILD.gn
+@@ -2,9 +2,11 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/python.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//third_party/jinja2/jinja2.gni")
+ 
++# TODO(crbug.com/1194274): Investigate nondeterminism in Py3 builds.
+ action("precompile_templates") {
+   sources = mojom_generator_sources
+   sources += [
+diff --git a/chromium/mojo/public/tools/bindings/gen_data_files_list.py b/chromium/mojo/public/tools/bindings/gen_data_files_list.py
+index 79c9e50efce..8b78d092418 100644
+--- a/chromium/mojo/public/tools/bindings/gen_data_files_list.py
++++ b/chromium/mojo/public/tools/bindings/gen_data_files_list.py
+@@ -18,7 +18,6 @@ import os
+ import re
+ import sys
+ 
+-from cStringIO import StringIO
+ from optparse import OptionParser
+ 
+ sys.path.insert(
+@@ -41,12 +40,9 @@ def main():
+   pattern = re.compile(options.pattern)
+   files = [f for f in os.listdir(options.directory) if pattern.match(f)]
+ 
+-  stream = StringIO()
+-  for f in files:
+-    print(f, file=stream)
++  contents = '\n'.join(f for f in files) + '\n'
++  WriteFile(contents, options.output)
+ 
+-  WriteFile(stream.getvalue(), options.output)
+-  stream.close()
+ 
+ if __name__ == '__main__':
+   sys.exit(main())
+diff --git a/chromium/mojo/public/tools/bindings/generators/mojom_java_generator.py b/chromium/mojo/public/tools/bindings/generators/mojom_java_generator.py
+index 96b2fdfae0c..00b9dccd00c 100644
+--- a/chromium/mojo/public/tools/bindings/generators/mojom_java_generator.py
++++ b/chromium/mojo/public/tools/bindings/generators/mojom_java_generator.py
+@@ -25,6 +25,10 @@ sys.path.append(os.path.join(os.path.dirname(__file__), os.pardir,
+                              'build', 'android', 'gyp'))
+ from util import build_utils
+ 
++# TODO(crbug.com/1174969): Remove this once Python2 is obsoleted.
++if sys.version_info.major != 2:
++  basestring = str
++  long = int
+ 
+ GENERATOR_PREFIX = 'java'
+ 
+diff --git a/chromium/mojo/public/tools/mojom/mojom/generate/generator.py b/chromium/mojo/public/tools/mojom/mojom/generate/generator.py
+index de62260a5c9..4a1c73fcf82 100644
+--- a/chromium/mojo/public/tools/mojom/mojom/generate/generator.py
++++ b/chromium/mojo/public/tools/mojom/mojom/generate/generator.py
+@@ -136,9 +136,14 @@ class Stylizer(object):
+ 
+ def WriteFile(contents, full_path):
+   # If |contents| is same with the file content, we skip updating.
++  if not isinstance(contents, bytes):
++    data = contents.encode('utf8')
++  else:
++    data = contents
++
+   if os.path.isfile(full_path):
+     with open(full_path, 'rb') as destination_file:
+-      if destination_file.read() == contents:
++      if destination_file.read() == data:
+         return
+ 
+   # Make sure the containing directory exists.
+@@ -146,11 +151,8 @@ def WriteFile(contents, full_path):
+   fileutil.EnsureDirectoryExists(full_dir)
+ 
+   # Dump the data to disk.
+-  with open(full_path, "wb") as f:
+-    if not isinstance(contents, bytes):
+-      f.write(contents.encode('utf-8'))
+-    else:
+-      f.write(contents)
++  with open(full_path, 'wb') as f:
++    f.write(data)
+ 
+ 
+ def AddComputedData(module):
+diff --git a/chromium/mojo/public/tools/mojom/mojom/generate/module.py b/chromium/mojo/public/tools/mojom/mojom/generate/module.py
+index ebbc9b322ea..3d026429bbc 100644
+--- a/chromium/mojo/public/tools/mojom/mojom/generate/module.py
++++ b/chromium/mojo/public/tools/mojom/mojom/generate/module.py
+@@ -398,7 +398,8 @@ class Field(object):
+ 
+ 
+ class StructField(Field):
+-  pass
++  def __hash__(self):
++    return super(Field, self).__hash__()
+ 
+ 
+ class UnionField(Field):
+diff --git a/chromium/mojo/public/tools/mojom/mojom/generate/template_expander.py b/chromium/mojo/public/tools/mojom/mojom/generate/template_expander.py
+index 7a300560246..8d9e26fb7f6 100644
+--- a/chromium/mojo/public/tools/mojom/mojom/generate/template_expander.py
++++ b/chromium/mojo/public/tools/mojom/mojom/generate/template_expander.py
+@@ -75,9 +75,9 @@ def PrecompileTemplates(generator_modules, output_dir):
+                 os.path.dirname(module.__file__), generator.GetTemplatePrefix())
+         ]))
+     jinja_env.filters.update(generator.GetFilters())
+-    jinja_env.compile_templates(
+-        os.path.join(output_dir, "%s.zip" % generator.GetTemplatePrefix()),
+-        extensions=["tmpl"],
+-        zip="stored",
+-        py_compile=True,
+-        ignore_errors=False)
++    jinja_env.compile_templates(os.path.join(
++        output_dir, "%s.zip" % generator.GetTemplatePrefix()),
++                                extensions=["tmpl"],
++                                zip="stored",
++                                py_compile=sys.version_info.major < 3,
++                                ignore_errors=False)
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/blink_v8_bridge.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/blink_v8_bridge.py
+index 3225ecca6e4..fc078d31b55 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/blink_v8_bridge.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/blink_v8_bridge.py
+@@ -344,7 +344,7 @@ def make_default_value_expr(idl_type, default_value):
+     """
+     assert default_value.is_type_compatible_with(idl_type)
+ 
+-    class DefaultValueExpr:
++    class DefaultValueExpr(object):
+         _ALLOWED_SYMBOLS_IN_DEPS = ("isolate")
+ 
+         def __init__(self, initializer_expr, initializer_deps,
+@@ -502,7 +502,7 @@ def make_v8_to_blink_value(blink_var_name,
+     assert isinstance(blink_var_name, str)
+     assert isinstance(v8_value_expr, str)
+     assert isinstance(idl_type, web_idl.IdlType)
+-    assert (argument_index is None or isinstance(argument_index, (int, long)))
++    assert (argument_index is None or isinstance(argument_index, int))
+     assert (default_value is None
+             or isinstance(default_value, web_idl.LiteralConstant))
+ 
+@@ -622,7 +622,7 @@ def make_v8_to_blink_value_variadic(blink_var_name, v8_array,
+     """
+     assert isinstance(blink_var_name, str)
+     assert isinstance(v8_array, str)
+-    assert isinstance(v8_array_start_index, (int, long))
++    assert isinstance(v8_array_start_index, int)
+     assert isinstance(idl_type, web_idl.IdlType)
+ 
+     pattern = ("auto&& ${{{_1}}} = "
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
+index 4a6df513068..8b51f23a409 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/callback_interface.py
+@@ -177,7 +177,7 @@ def generate_callback_interface(callback_interface_identifier):
+          prop_install_mode=PropInstallMode.UNCONDITIONAL,
+          trampoline_var_name=None,
+          attribute_entries=[],
+-         constant_entries=filter(is_unconditional, constant_entries),
++         constant_entries=list(filter(is_unconditional, constant_entries)),
+          exposed_construct_entries=[],
+          operation_entries=[])
+     (install_interface_template_decl, install_interface_template_def,
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/code_node.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/code_node.py
+index 52972fefe20..e5ae9d9629e 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/code_node.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/code_node.py
+@@ -503,13 +503,13 @@ class CompositeNode(CodeNode):
+         gensym_kwargs = {}
+         template_vars = {}
+         for arg in args:
+-            assert isinstance(arg, (CodeNode, int, long, str))
++            assert isinstance(arg, (CodeNode, int, str))
+             gensym = CodeNode.gensym()
+             gensym_args.append("${{{}}}".format(gensym))
+             template_vars[gensym] = arg
+         for key, value in kwargs.items():
+-            assert isinstance(key, (int, long, str))
+-            assert isinstance(value, (CodeNode, int, long, str))
++            assert isinstance(key, (int, str))
++            assert isinstance(value, (CodeNode, int, str))
+             gensym = CodeNode.gensym()
+             gensym_kwargs[key] = "${{{}}}".format(gensym)
+             template_vars[gensym] = value
+@@ -602,7 +602,7 @@ class ListNode(CodeNode):
+     def insert(self, index, node):
+         if node is None:
+             return
+-        assert isinstance(index, (int, long))
++        assert isinstance(index, int)
+         assert isinstance(node, CodeNode)
+         assert node.outer is None and node.prev is None
+ 
+@@ -721,7 +721,7 @@ class SymbolScopeNode(SequenceNode):
+             if not scope_chains:
+                 return counts
+ 
+-            self_index = iter(scope_chains).next().index(self)
++            self_index = next(iter(scope_chains)).index(self)
+             scope_chains = map(
+                 lambda scope_chain: scope_chain[self_index + 1:], scope_chains)
+             scope_to_likeliness = {}
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_expr.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_expr.py
+index a229a6c71c9..5fa288dabf2 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_expr.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_expr.py
+@@ -109,7 +109,7 @@ def expr_and(terms):
+ 
+     if any(term.is_always_false for term in terms):
+         return _Expr(False)
+-    terms = filter(lambda x: not x.is_always_true, terms)
++    terms = list(filter(lambda x: not x.is_always_true, terms))
+     if not terms:
+         return _Expr(True)
+     if len(terms) == 1:
+@@ -124,7 +124,7 @@ def expr_or(terms):
+ 
+     if any(term.is_always_true for term in terms):
+         return _Expr(True)
+-    terms = filter(lambda x: not x.is_always_false, terms)
++    terms = list(filter(lambda x: not x.is_always_false, terms))
+     if not terms:
+         return _Expr(False)
+     if len(terms) == 1:
+@@ -222,7 +222,7 @@ def expr_from_exposure(exposure,
+     elif exposure.only_in_secure_contexts is False:
+         secure_context_term = _Expr(True)
+     else:
+-        terms = map(ref_enabled, exposure.only_in_secure_contexts)
++        terms = list(map(ref_enabled, exposure.only_in_secure_contexts))
+         secure_context_term = expr_or(
+             [_Expr("${is_in_secure_context}"),
+              expr_not(expr_and(terms))])
+@@ -275,10 +275,11 @@ def expr_from_exposure(exposure,
+ 
+     # [ContextEnabled]
+     if exposure.context_enabled_features:
+-        terms = map(
+-            lambda feature: _Expr(
+-                "${{context_feature_settings}}->is{}Enabled()".format(
+-                    feature)), exposure.context_enabled_features)
++        terms = list(
++            map(
++                lambda feature: _Expr(
++                    "${{context_feature_settings}}->is{}Enabled()".format(
++                        feature)), exposure.context_enabled_features))
+         context_enabled_terms.append(
+             expr_and([_Expr("${context_feature_settings}"),
+                       expr_or(terms)]))
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_format.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_format.py
+index 87d26eec3ca..f3e9d38247e 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_format.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_format.py
+@@ -23,7 +23,7 @@ class _TemplateFormatter(string.Formatter):
+         self._template_formatter_indexing_count_ = 0
+ 
+     def get_value(self, key, args, kwargs):
+-        if isinstance(key, (int, long)):
++        if isinstance(key, int):
+             return args[key]
+         assert isinstance(key, str)
+         if not key:
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
+index 2bcc4fed49a..e72282aa696 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/codegen_utils.py
+@@ -116,4 +116,4 @@ def write_code_node_to_file(code_node, filepath):
+ #                               stderr=format_result.error_message))
+ #
+ #    web_idl.file_io.write_to_file_if_changed(filepath, format_result.contents)
+-    web_idl.file_io.write_to_file_if_changed(filepath, rendered_text)
++    web_idl.file_io.write_to_file_if_changed(filepath, rendered_text.encode('utf-8'))
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/dictionary.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/dictionary.py
+index b39f0100410..4d68202296b 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/dictionary.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/dictionary.py
+@@ -993,7 +993,7 @@ def make_dict_trace_func(cg_context):
+         _2 = _blink_member_name(member).value_var
+         return TextNode(_format(pattern, _1=_1, _2=_2))
+ 
+-    body.extend(map(make_trace_member_node, own_members))
++    body.extend(list(map(make_trace_member_node, own_members)))
+     body.append(TextNode("BaseClass::Trace(visitor);"))
+ 
+     return func_decl, func_def
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+index 10ff30656ad..bfdf7128aac 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+@@ -582,7 +582,7 @@ def _make_blink_api_call(code_node,
+                          overriding_args=None):
+     assert isinstance(code_node, SymbolScopeNode)
+     assert isinstance(cg_context, CodeGenContext)
+-    assert num_of_args is None or isinstance(num_of_args, (int, long))
++    assert num_of_args is None or isinstance(num_of_args, int)
+     assert (overriding_args is None
+             or (isinstance(overriding_args, (list, tuple))
+                 and all(isinstance(arg, str) for arg in overriding_args)))
+@@ -1196,8 +1196,10 @@ def make_overload_dispatcher(cg_context):
+             did_use_break = did_use_break or can_fail
+ 
+         conditional = expr_or(
+-            map(lambda item: expr_from_exposure(item.function_like.exposure),
+-                items))
++            list(
++                map(
++                    lambda item: expr_from_exposure(item.function_like.exposure
++                                                    ), items)))
+         if not conditional.is_always_true:
+             node = CxxUnlikelyIfNode(cond=conditional, body=node)
+ 
+@@ -4642,7 +4644,7 @@ class _PropEntryConstructorGroup(_PropEntryBase):
+     def __init__(self, is_context_dependent, exposure_conditional, world,
+                  constructor_group, ctor_callback_name, ctor_func_length):
+         assert isinstance(ctor_callback_name, str)
+-        assert isinstance(ctor_func_length, (int, long))
++        assert isinstance(ctor_func_length, int)
+ 
+         _PropEntryBase.__init__(self, is_context_dependent,
+                                 exposure_conditional, world, constructor_group)
+@@ -4670,7 +4672,7 @@ class _PropEntryOperationGroup(_PropEntryBase):
+                  op_func_length,
+                  no_alloc_direct_callback_name=None):
+         assert isinstance(op_callback_name, str)
+-        assert isinstance(op_func_length, (int, long))
++        assert isinstance(op_func_length, int)
+ 
+         _PropEntryBase.__init__(self, is_context_dependent,
+                                 exposure_conditional, world, operation_group)
+@@ -5175,9 +5177,9 @@ def make_install_interface_template(cg_context, function_name, class_name, api_c
+     ])
+ 
+     if class_like.identifier == "CSSStyleDeclaration":
+-        css_properties = filter(
+-            lambda attr: "CSSProperty" in attr.extended_attributes,
+-            class_like.attributes)
++        css_properties = list(
++            filter(lambda attr: "CSSProperty" in attr.extended_attributes,
++                   class_like.attributes))
+         if css_properties:
+             prop_name_list = "".join(
+                 map(lambda attr: "\"{}\", ".format(attr.identifier),
+@@ -5567,8 +5569,8 @@ ${instance_object} = ${v8_context}->Global()->GetPrototype().As<v8::Object>();\
+             "V8DOMConfiguration::InstallConstants(${isolate}, "
+             "${interface_template}, ${prototype_template}, "
+             "kConstantCallbackTable, base::size(kConstantCallbackTable));")
+-    constant_callback_entries = filter(lambda entry: entry.const_callback_name,
+-                                       constant_entries)
++    constant_callback_entries = list(filter(lambda entry: entry.const_callback_name,
++                                       constant_entries))
+     install_properties(table_name, constant_callback_entries,
+                        _make_constant_callback_registration_table,
+                        installer_call_text)
+@@ -5584,8 +5586,8 @@ ${instance_object} = ${v8_context}->Global()->GetPrototype().As<v8::Object>();\
+             "V8DOMConfiguration::InstallConstants(${isolate}, "
+             "${interface_template}, ${prototype_template}, "
+             "kConstantValueTable, base::size(kConstantValueTable));")
+-    constant_value_entries = filter(
+-        lambda entry: not entry.const_callback_name, constant_entries)
++    constant_value_entries = list(filter(
++        lambda entry: not entry.const_callback_name, constant_entries))
+     install_properties(table_name, constant_value_entries,
+                        _make_constant_value_registration_table,
+                        installer_call_text)
+@@ -6336,8 +6338,8 @@ def make_v8_context_snapshot_api(cg_context, component, attribute_entries,
+     assert isinstance(component, web_idl.Component)
+ 
+     derived_interfaces = cg_context.interface.deriveds
+-    derived_names = map(lambda interface: interface.identifier,
+-                        derived_interfaces)
++    derived_names = list(
++        map(lambda interface: interface.identifier, derived_interfaces))
+     derived_names.append(cg_context.interface.identifier)
+     if not ("Window" in derived_names or "HTMLDocument" in derived_names):
+         return None, None
+@@ -6411,9 +6413,11 @@ def _make_v8_context_snapshot_get_reference_table_function(
+     collect_callbacks(named_properties_object_callback_defs)
+     collect_callbacks(cross_origin_property_callback_defs)
+ 
+-    entry_nodes = map(
+-        lambda name: TextNode("reinterpret_cast<intptr_t>({}),".format(name)),
+-        filter(None, callback_names))
++    entry_nodes = list(
++        map(
++            lambda name: TextNode("reinterpret_cast<intptr_t>({}),".format(name
++                                                                           )),
++            filter(None, callback_names)))
+     table_node = ListNode([
+         TextNode("using namespace ${class_name}Callbacks;"),
+         TextNode("static const intptr_t kReferenceTable[] = {"),
+@@ -6451,10 +6455,11 @@ def _make_v8_context_snapshot_install_props_per_context_function(
+         class_name=None,
+         prop_install_mode=PropInstallMode.V8_CONTEXT_SNAPSHOT,
+         trampoline_var_name=None,
+-        attribute_entries=filter(selector, attribute_entries),
+-        constant_entries=filter(selector, constant_entries),
+-        exposed_construct_entries=filter(selector, exposed_construct_entries),
+-        operation_entries=filter(selector, operation_entries))
++        attribute_entries=list(filter(selector, attribute_entries)),
++        constant_entries=list(filter(selector, constant_entries)),
++        exposed_construct_entries=list(
++            filter(selector, exposed_construct_entries)),
++        operation_entries=list(filter(selector, operation_entries)))
+ 
+     return func_decl, func_def
+ 
+@@ -6810,11 +6815,11 @@ def generate_interface(interface_identifier):
+          class_name=impl_class_name,
+          prop_install_mode=PropInstallMode.UNCONDITIONAL,
+          trampoline_var_name=tp_install_unconditional_props,
+-         attribute_entries=filter(is_unconditional, attribute_entries),
+-         constant_entries=filter(is_unconditional, constant_entries),
+-         exposed_construct_entries=filter(is_unconditional,
+-                                          exposed_construct_entries),
+-         operation_entries=filter(is_unconditional, operation_entries))
++         attribute_entries=list(filter(is_unconditional, attribute_entries)),
++         constant_entries=list(filter(is_unconditional, constant_entries)),
++         exposed_construct_entries=list(
++             filter(is_unconditional, exposed_construct_entries)),
++         operation_entries=list(filter(is_unconditional, operation_entries)))
+     (install_context_independent_props_decl,
+      install_context_independent_props_def,
+      install_context_independent_props_trampoline) = make_install_properties(
+@@ -6823,11 +6828,14 @@ def generate_interface(interface_identifier):
+          class_name=impl_class_name,
+          prop_install_mode=PropInstallMode.CONTEXT_INDEPENDENT,
+          trampoline_var_name=tp_install_context_independent_props,
+-         attribute_entries=filter(is_context_independent, attribute_entries),
+-         constant_entries=filter(is_context_independent, constant_entries),
+-         exposed_construct_entries=filter(is_context_independent,
+-                                          exposed_construct_entries),
+-         operation_entries=filter(is_context_independent, operation_entries))
++         attribute_entries=list(
++             filter(is_context_independent, attribute_entries)),
++         constant_entries=list(filter(is_context_independent,
++                                      constant_entries)),
++         exposed_construct_entries=list(
++             filter(is_context_independent, exposed_construct_entries)),
++         operation_entries=list(
++             filter(is_context_independent, operation_entries)))
+     (install_context_dependent_props_decl, install_context_dependent_props_def,
+      install_context_dependent_props_trampoline) = make_install_properties(
+          cg_context,
+@@ -6835,11 +6843,13 @@ def generate_interface(interface_identifier):
+          class_name=impl_class_name,
+          prop_install_mode=PropInstallMode.CONTEXT_DEPENDENT,
+          trampoline_var_name=tp_install_context_dependent_props,
+-         attribute_entries=filter(is_context_dependent, attribute_entries),
+-         constant_entries=filter(is_context_dependent, constant_entries),
+-         exposed_construct_entries=filter(is_context_dependent,
+-                                          exposed_construct_entries),
+-         operation_entries=filter(is_context_dependent, operation_entries))
++         attribute_entries=list(filter(is_context_dependent,
++                                       attribute_entries)),
++         constant_entries=list(filter(is_context_dependent, constant_entries)),
++         exposed_construct_entries=list(
++             filter(is_context_dependent, exposed_construct_entries)),
++         operation_entries=list(filter(is_context_dependent,
++                                       operation_entries)))
+     (install_interface_template_decl, install_interface_template_def,
+      install_interface_template_trampoline) = make_install_interface_template(
+          cg_context,
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/mako_renderer.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/mako_renderer.py
+index b4c70553863..f3a2fcd772d 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/mako_renderer.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/mako_renderer.py
+@@ -105,7 +105,7 @@ class MakoRenderer(object):
+             on_error = self._caller_stack_on_error
+             if (len(current) <= len(on_error)
+                     and all(current[i] == on_error[i]
+-                            for i in xrange(len(current)))):
++                            for i in range(len(current)))):
+                 pass  # Error happened in a deeper caller.
+             else:
+                 self._caller_stack_on_error = list(self._caller_stack)
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/style_format.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/style_format.py
+index dc3493cc394..017d3d47bb3 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/style_format.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/style_format.py
+@@ -70,8 +70,13 @@ def gn_format(contents, filename=None):
+ 
+ 
+ def _invoke_format_command(command_line, filename, contents):
+-    proc = subprocess.Popen(
+-        command_line, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
++    kwargs = {}
++    if sys.version_info.major != 2:
++        kwargs['encoding'] = 'utf-8'
++    proc = subprocess.Popen(command_line,
++                            stdin=subprocess.PIPE,
++                            stdout=subprocess.PIPE,
++                            **kwargs)
+     stdout_output, stderr_output = proc.communicate(input=contents)
+     exit_code = proc.wait()
+ 
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
+index 0d8f4c0f303..e666a9b668e 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/bind_gen/task_queue.py
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import functools
+ import multiprocessing
+ 
+ from .package_initializer import package_initializer
+@@ -76,7 +77,7 @@ class TaskQueue(object):
+         if not report_progress:
+             return
+ 
+-        done_count = reduce(
++        done_count = functools.reduce(
+             lambda count, worker_task: count + bool(worker_task.ready()),
+             self._worker_tasks, 0)
+         report_progress(len(self._worker_tasks), done_count)
+@@ -85,4 +86,4 @@ class TaskQueue(object):
+ def _task_queue_run_tasks(tasks):
+     for task in tasks:
+         func, args, kwargs = task
+-        apply(func, args, kwargs)
++        func(*args, **kwargs)
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/code_generator.py b/chromium/third_party/blink/renderer/bindings/scripts/code_generator.py
+index e8280be7213..e49e6eb965e 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/code_generator.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/code_generator.py
+@@ -13,6 +13,7 @@ import re
+ import sys
+ 
+ from idl_types import set_ancestors, IdlType
++from itertools import groupby
+ from v8_globals import includes
+ from v8_interface import constant_filters
+ from v8_types import set_component_dirs
+@@ -43,6 +44,7 @@ TEMPLATES_DIR = os.path.normpath(
+ # after path[0] == invoking script dir
+ sys.path.insert(1, THIRD_PARTY_DIR)
+ import jinja2
++from jinja2.filters import make_attrgetter, environmentfilter
+ 
+ 
+ def generate_indented_conditional(code, conditional):
+@@ -88,6 +90,13 @@ def runtime_enabled_if(code, name):
+     return generate_indented_conditional(code, function)
+ 
+ 
++@environmentfilter
++def do_stringify_key_group_by(environment, value, attribute):
++    expr = make_attrgetter(environment, attribute)
++    key = lambda item: '' if expr(item) is None else str(expr(item))
++    return groupby(sorted(value, key=key), expr)
++
++
+ def initialize_jinja_env(cache_dir):
+     jinja_env = jinja2.Environment(
+         loader=jinja2.FileSystemLoader(TEMPLATES_DIR),
+@@ -117,6 +126,7 @@ def initialize_jinja_env(cache_dir):
+     })
+     jinja_env.filters.update(constant_filters())
+     jinja_env.filters.update(method_filters())
++    jinja_env.filters["stringifykeygroupby"] = do_stringify_key_group_by
+     return jinja_env
+ 
+ 
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/generate_origin_trial_features.py b/chromium/third_party/blink/renderer/bindings/scripts/generate_origin_trial_features.py
+index 130004eae83..04c0fabcef2 100755
+--- a/chromium/third_party/blink/renderer/bindings/scripts/generate_origin_trial_features.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/generate_origin_trial_features.py
+@@ -80,7 +80,7 @@ def read_idl_file(reader, idl_filename):
+     assert len(interfaces) == 1, (
+         "Expected one interface in file %r, found %d" %
+         (idl_filename, len(interfaces)))
+-    return (interfaces.values()[0], includes)
++    return (list(interfaces.values())[0], includes)
+ 
+ 
+ def interface_is_global(interface):
+@@ -281,7 +281,7 @@ def main():
+ 
+     info_provider = create_component_info_provider(
+         os.path.normpath(options.info_dir), options.target_component)
+-    idl_filenames = map(str.strip, open(options.idl_files_list))
++    idl_filenames = list(map(str.strip, open(options.idl_files_list)))
+ 
+     generate_origin_trial_features(info_provider, options, idl_filenames)
+     return 0
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/idl_definitions.py b/chromium/third_party/blink/renderer/bindings/scripts/idl_definitions.py
+index 14e6e9d3f87..b027818aef2 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/idl_definitions.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/idl_definitions.py
+@@ -394,7 +394,8 @@ class IdlInterface(object):
+             else:
+                 raise ValueError('Unrecognized node class: %s' % child_class)
+ 
+-        if len(filter(None, [self.iterable, self.maplike, self.setlike])) > 1:
++        if len(list(filter(None,
++                           [self.iterable, self.maplike, self.setlike]))) > 1:
+             raise ValueError(
+                 'Interface can only have one of iterable<>, maplike<> and setlike<>.'
+             )
+@@ -512,6 +513,9 @@ class IdlAttribute(TypedObject):
+     def accept(self, visitor):
+         visitor.visit_attribute(self)
+ 
++    def __lt__(self, other):
++        return self.name < other.name
++
+ 
+ ################################################################################
+ # Constants
+@@ -852,7 +856,7 @@ class IdlIncludes(object):
+ ################################################################################
+ 
+ 
+-class Exposure:
++class Exposure(object):
+     """An Exposure holds one Exposed or RuntimeEnabled condition.
+     Each exposure has two properties: exposed and runtime_enabled.
+     Exposure(e, r) corresponds to [Exposed(e r)]. Exposure(e) corresponds to
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/idl_reader.py b/chromium/third_party/blink/renderer/bindings/scripts/idl_reader.py
+index 8d72865a6ca..b80eebdcd61 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/idl_reader.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/idl_reader.py
+@@ -55,8 +55,8 @@ def validate_blink_idl_definitions(idl_filename, idl_file_basename,
+          definitions. There is no filename convention in this case.
+        - Otherwise, an IDL file is invalid.
+     """
+-    targets = (
+-        definitions.interfaces.values() + definitions.dictionaries.values())
++    targets = (list(definitions.interfaces.values()) +
++               list(definitions.dictionaries.values()))
+     number_of_targets = len(targets)
+     if number_of_targets > 1:
+         raise Exception(
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/idl_types.py b/chromium/third_party/blink/renderer/bindings/scripts/idl_types.py
+index cd4f0c3513b..ab95e9c0b08 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/idl_types.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/idl_types.py
+@@ -349,7 +349,7 @@ class IdlUnionType(IdlTypeBase):
+         return True
+ 
+     def single_matching_member_type(self, predicate):
+-        matching_types = filter(predicate, self.flattened_member_types)
++        matching_types = list(filter(predicate, self.flattened_member_types))
+         if len(matching_types) > 1:
+             raise ValueError('%s is ambiguous.' % self.name)
+         return matching_types[0] if matching_types else None
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/utilities.py b/chromium/third_party/blink/renderer/bindings/scripts/utilities.py
+index e1677ee7bd6..3c5006f064f 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/utilities.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/utilities.py
+@@ -196,8 +196,9 @@ class ComponentInfoProviderModules(ComponentInfoProvider):
+ 
+     @property
+     def callback_functions(self):
+-        return dict(self._component_info_core['callback_functions'].items() +
+-                    self._component_info_modules['callback_functions'].items())
++        return dict(
++            list(self._component_info_core['callback_functions'].items()) +
++            list(self._component_info_modules['callback_functions'].items()))
+ 
+     @property
+     def specifier_for_export(self):
+@@ -209,8 +210,8 @@ class ComponentInfoProviderModules(ComponentInfoProvider):
+ 
+ 
+ def load_interfaces_info_overall_pickle(info_dir):
+-    with open(os.path.join(info_dir,
+-                           'interfaces_info.pickle')) as interface_info_file:
++    with open(os.path.join(info_dir, 'interfaces_info.pickle'),
++              mode='rb') as interface_info_file:
+         return pickle.load(interface_info_file)
+ 
+ 
+@@ -236,23 +237,20 @@ def merge_dict_recursively(target, diff):
+ 
+ def create_component_info_provider_core(info_dir):
+     interfaces_info = load_interfaces_info_overall_pickle(info_dir)
+-    with open(
+-            os.path.join(info_dir, 'core',
+-                         'component_info_core.pickle')) as component_info_file:
++    with open(os.path.join(info_dir, 'core', 'component_info_core.pickle'),
++              mode='rb') as component_info_file:
+         component_info = pickle.load(component_info_file)
+     return ComponentInfoProviderCore(interfaces_info, component_info)
+ 
+ 
+ def create_component_info_provider_modules(info_dir):
+     interfaces_info = load_interfaces_info_overall_pickle(info_dir)
+-    with open(
+-            os.path.join(info_dir, 'core',
+-                         'component_info_core.pickle')) as component_info_file:
++    with open(os.path.join(info_dir, 'core', 'component_info_core.pickle'),
++              mode='rb') as component_info_file:
+         component_info_core = pickle.load(component_info_file)
+-    with open(
+-            os.path.join(
+-                info_dir, 'modules',
+-                'component_info_modules.pickle')) as component_info_file:
++    with open(os.path.join(info_dir, 'modules',
++                           'component_info_modules.pickle'),
++              mode='rb') as component_info_file:
+         component_info_modules = pickle.load(component_info_file)
+     return ComponentInfoProviderModules(interfaces_info, component_info_core,
+                                         component_info_modules)
+@@ -356,7 +354,7 @@ def write_pickle_file(pickle_filename, data):
+     pickle_filename = abs(pickle_filename)
+     # If |data| is same with the file content, we skip updating.
+     if os.path.isfile(pickle_filename):
+-        with open(pickle_filename) as pickle_file:
++        with open(pickle_filename, 'rb') as pickle_file:
+             try:
+                 if pickle.load(pickle_file) == data:
+                     return
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/v8_interface.py b/chromium/third_party/blink/renderer/bindings/scripts/v8_interface.py
+index a43260414db..a85b03abe75 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/v8_interface.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/v8_interface.py
+@@ -189,7 +189,7 @@ def context_enabled_features(attributes):
+         return sorted([
+             member for member in members
+             if member.get(KEY) and not member.get('exposed_test')
+-        ])
++        ], key=lambda item: item['name'])
+ 
+     def member_filter_by_name(members, name):
+         return [member for member in members if member[KEY] == name]
+@@ -612,7 +612,8 @@ def interface_context(interface, interfaces, component_info):
+         sorted(
+             origin_trial_features(interface, context['constants'],
+                                   context['attributes'], context['methods']) +
+-            context_enabled_features(context['attributes'])),
++            context_enabled_features(context['attributes']),
++            key=lambda item: item['name']),
+     })
+     if context['optional_features']:
+         includes.add('platform/bindings/v8_per_context_data.h')
+@@ -1356,9 +1357,9 @@ def resolution_tests_methods(effective_overloads):
+ 
+     # Extract argument and IDL type to simplify accessing these in each loop.
+     arguments = [method['arguments'][index] for method in methods]
+-    arguments_methods = zip(arguments, methods)
++    arguments_methods = list(zip(arguments, methods))
+     idl_types = [argument['idl_type_object'] for argument in arguments]
+-    idl_types_methods = zip(idl_types, methods)
++    idl_types_methods = list(zip(idl_types, methods))
+ 
+     # We can’t do a single loop through all methods or simply sort them, because
+     # a method may be listed in multiple steps of the resolution algorithm, and
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/v8_methods.py b/chromium/third_party/blink/renderer/bindings/scripts/v8_methods.py
+index 5f1f89a3def..6ee8a407798 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/v8_methods.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/v8_methods.py
+@@ -46,6 +46,10 @@ import v8_types
+ import v8_utilities
+ from v8_utilities import (has_extended_attribute_value, is_unforgeable)
+ 
++# TODO: Remove this once Python2 is obsoleted.
++if sys.version_info.major != 2:
++    basestring = str
++
+ 
+ def method_is_visible(method, interface_is_partial):
+     if 'overloads' in method:
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/v8_utilities.py b/chromium/third_party/blink/renderer/bindings/scripts/v8_utilities.py
+index 2ecd6923320..fcfc48371b1 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/v8_utilities.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/v8_utilities.py
+@@ -271,7 +271,7 @@ EXPOSED_WORKERS = set([
+ ])
+ 
+ 
+-class ExposureSet:
++class ExposureSet(object):
+     """An ExposureSet is a collection of Exposure instructions."""
+ 
+     def __init__(self, exposures=None):
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/callback_interface.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/callback_interface.py
+index 13fb7c7068d..b73b7710687 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/callback_interface.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/callback_interface.py
+@@ -91,11 +91,13 @@ class CallbackInterface(UserDefinedType, WithExtendedAttributes,
+             for operation_ir in ir.operations
+         ])
+         self._operation_groups = tuple([
+-            OperationGroup(
+-                operation_group_ir,
+-                filter(lambda x: x.identifier == operation_group_ir.identifier,
+-                       self._operations),
+-                owner=self) for operation_group_ir in ir.operation_groups
++            OperationGroup(operation_group_ir,
++                           list(
++                               filter(
++                                   lambda x: x.identifier == operation_group_ir
++                                   .identifier, self._operations)),
++                           owner=self)
++            for operation_group_ir in ir.operation_groups
+         ])
+ 
+     @property
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/database.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/database.py
+index c92cf48eb2a..f5d59129449 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/database.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/database.py
+@@ -156,4 +156,4 @@ class Database(object):
+         return self._view_by_kind(Database._Kind.UNION)
+ 
+     def _view_by_kind(self, kind):
+-        return self._impl.find_by_kind(kind).values()
++        return list(self._impl.find_by_kind(kind).values())
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/exposure.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/exposure.py
+index abaeef39c30..e36cf7439ae 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/exposure.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/exposure.py
+@@ -8,8 +8,11 @@ from .runtime_enabled_features import RuntimeEnabledFeatures
+ class _Feature(str):
+     """Represents a runtime-enabled feature."""
+ 
++    def __new__(cls, value):
++        return str.__new__(cls, value)
++
+     def __init__(self, value):
+-        str.__init__(self, value)
++        str.__init__(self)
+         self._is_context_dependent = (
+             RuntimeEnabledFeatures.is_context_dependent(self))
+ 
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/function_like.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/function_like.py
+index 648c70d803d..1712f19c672 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/function_like.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/function_like.py
+@@ -71,8 +71,9 @@ class FunctionLike(WithIdentifier):
+     def num_of_required_arguments(self):
+         """Returns the number of required arguments."""
+         return len(
+-            filter(lambda arg: not (arg.is_optional or arg.is_variadic),
+-                   self.arguments))
++            list(
++                filter(lambda arg: not (arg.is_optional or arg.is_variadic),
++                       self.arguments)))
+ 
+ 
+ class OverloadGroup(WithIdentifier):
+@@ -171,8 +172,7 @@ class OverloadGroup(WithIdentifier):
+         Returns the effective overload set.
+         https://heycam.github.io/webidl/#compute-the-effective-overload-set
+         """
+-        assert argument_count is None or isinstance(argument_count,
+-                                                    (int, long))
++        assert argument_count is None or isinstance(argument_count, int)
+ 
+         N = argument_count
+         S = []
+@@ -188,21 +188,21 @@ class OverloadGroup(WithIdentifier):
+ 
+             S.append(
+                 OverloadGroup.EffectiveOverloadItem(
+-                    X, map(lambda arg: arg.idl_type, X.arguments),
+-                    map(lambda arg: arg.optionality, X.arguments)))
++                    X, list(map(lambda arg: arg.idl_type, X.arguments)),
++                    list(map(lambda arg: arg.optionality, X.arguments))))
+ 
+             if X.is_variadic:
+-                for i in xrange(n, max(maxarg, N)):
+-                    t = map(lambda arg: arg.idl_type, X.arguments)
+-                    o = map(lambda arg: arg.optionality, X.arguments)
+-                    for _ in xrange(n, i + 1):
++                for i in range(n, max(maxarg, N)):
++                    t = list(map(lambda arg: arg.idl_type, X.arguments))
++                    o = list(map(lambda arg: arg.optionality, X.arguments))
++                    for _ in range(n, i + 1):
+                         t.append(X.arguments[-1].idl_type)
+                         o.append(X.arguments[-1].optionality)
+                     S.append(OverloadGroup.EffectiveOverloadItem(X, t, o))
+ 
+-            t = map(lambda arg: arg.idl_type, X.arguments)
+-            o = map(lambda arg: arg.optionality, X.arguments)
+-            for i in xrange(n - 1, -1, -1):
++            t = list(map(lambda arg: arg.idl_type, X.arguments))
++            o = list(map(lambda arg: arg.optionality, X.arguments))
++            for i in range(n - 1, -1, -1):
+                 if X.arguments[i].optionality == IdlType.Optionality.REQUIRED:
+                     break
+                 S.append(OverloadGroup.EffectiveOverloadItem(X, t[:i], o[:i]))
+@@ -222,7 +222,7 @@ class OverloadGroup(WithIdentifier):
+             for item in items)
+         assert len(items) > 1
+ 
+-        for index in xrange(len(items[0].type_list)):
++        for index in range(len(items[0].type_list)):
+             # Assume that the given items are valid, and we only need to test
+             # the two types.
+             if OverloadGroup.are_distinguishable_types(
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/idl_compiler.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/idl_compiler.py
+index c5ee2bd8a3d..58315072480 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/idl_compiler.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/idl_compiler.py
+@@ -149,8 +149,8 @@ class IdlCompiler(object):
+         for old_ir in old_irs:
+             new_ir = make_copy(old_ir)
+             self._ir_map.add(new_ir)
+-            new_ir.attributes = filter(not_disabled, new_ir.attributes)
+-            new_ir.operations = filter(not_disabled, new_ir.operations)
++            new_ir.attributes = list(filter(not_disabled, new_ir.attributes))
++            new_ir.operations = list(filter(not_disabled, new_ir.operations))
+ 
+     def _record_defined_in_partial_and_mixin(self):
+         old_irs = self._ir_map.irs_of_kinds(
+@@ -231,7 +231,7 @@ class IdlCompiler(object):
+                       only_to_members_of_partial_or_mixin=False)
+             propagate_to_exposure(propagate)
+ 
+-            map(process_member_like, ir.iter_all_members())
++            list(map(process_member_like, ir.iter_all_members()))
+ 
+         def process_member_like(ir):
+             propagate = functools.partial(propagate_extattr, ir=ir)
+@@ -257,7 +257,7 @@ class IdlCompiler(object):
+ 
+         self._ir_map.move_to_new_phase()
+ 
+-        map(process_interface_like, old_irs)
++        list(map(process_interface_like, old_irs))
+ 
+     def _determine_blink_headers(self):
+         irs = self._ir_map.irs_of_kinds(
+@@ -422,9 +422,9 @@ class IdlCompiler(object):
+             assert not new_interface.deriveds
+             derived_set = identifier_to_derived_set.get(
+                 new_interface.identifier, set())
+-            new_interface.deriveds = map(
+-                lambda id_: self._ref_to_idl_def_factory.create(id_),
+-                sorted(derived_set))
++            new_interface.deriveds = list(
++                map(lambda id_: self._ref_to_idl_def_factory.create(id_),
++                    sorted(derived_set)))
+ 
+     def _supplement_missing_html_constructor_operation(self):
+         # Temporary mitigation of misuse of [HTMLConstructor]
+@@ -553,7 +553,8 @@ class IdlCompiler(object):
+             self._ir_map.add(new_ir)
+ 
+             for group in new_ir.iter_all_overload_groups():
+-                exposures = map(lambda overload: overload.exposure, group)
++                exposures = list(map(lambda overload: overload.exposure,
++                                     group))
+ 
+                 # [Exposed]
+                 if any(not exposure.global_names_and_features
+@@ -653,8 +654,8 @@ class IdlCompiler(object):
+             constructs = set()
+             for global_name in global_names:
+                 constructs.update(exposed_map.get(global_name, []))
+-            new_ir.exposed_constructs = map(
+-                self._ref_to_idl_def_factory.create, sorted(constructs))
++            new_ir.exposed_constructs = list(
++                map(self._ref_to_idl_def_factory.create, sorted(constructs)))
+ 
+             assert not new_ir.legacy_window_aliases
+             if new_ir.identifier != 'Window':
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/interface.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/interface.py
+index 65d24e529d1..067ef2eb0b2 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/interface.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/interface.py
+@@ -180,8 +180,9 @@ class Interface(UserDefinedType, WithExtendedAttributes, WithCodeGeneratorInfo,
+         self._constructor_groups = tuple([
+             ConstructorGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._constructors),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._constructors)),
+                 owner=self) for group_ir in ir.constructor_groups
+         ])
+         assert len(self._constructor_groups) <= 1
+@@ -192,8 +193,9 @@ class Interface(UserDefinedType, WithExtendedAttributes, WithCodeGeneratorInfo,
+         self._named_constructor_groups = tuple([
+             ConstructorGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._named_constructors),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._named_constructors)),
+                 owner=self) for group_ir in ir.named_constructor_groups
+         ])
+         self._operations = tuple([
+@@ -203,22 +205,23 @@ class Interface(UserDefinedType, WithExtendedAttributes, WithCodeGeneratorInfo,
+         self._operation_groups = tuple([
+             OperationGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._operations),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._operations)),
+                 owner=self) for group_ir in ir.operation_groups
+         ])
+         self._exposed_constructs = tuple(ir.exposed_constructs)
+         self._legacy_window_aliases = tuple(ir.legacy_window_aliases)
+         self._indexed_and_named_properties = None
+-        indexed_and_named_property_operations = filter(
+-            lambda x: x.is_indexed_or_named_property_operation,
+-            self._operations)
++        indexed_and_named_property_operations = list(
++            filter(lambda x: x.is_indexed_or_named_property_operation,
++                   self._operations))
+         if indexed_and_named_property_operations:
+             self._indexed_and_named_properties = IndexedAndNamedProperties(
+                 indexed_and_named_property_operations, owner=self)
+         self._stringifier = None
+-        stringifier_operation_irs = filter(lambda x: x.is_stringifier,
+-                                           ir.operations)
++        stringifier_operation_irs = list(
++            filter(lambda x: x.is_stringifier, ir.operations))
+         if stringifier_operation_irs:
+             assert len(stringifier_operation_irs) == 1
+             op_ir = make_copy(stringifier_operation_irs[0])
+@@ -231,8 +234,9 @@ class Interface(UserDefinedType, WithExtendedAttributes, WithCodeGeneratorInfo,
+             attribute = None
+             if operation.stringifier_attribute:
+                 attr_id = operation.stringifier_attribute
+-                attributes = filter(lambda x: x.identifier == attr_id,
+-                                    self._attributes)
++                attributes = list(
++                    filter(lambda x: x.identifier == attr_id,
++                           self._attributes))
+                 assert len(attributes) == 1
+                 attribute = attributes[0]
+             self._stringifier = Stringifier(operation, attribute, owner=self)
+@@ -578,8 +582,9 @@ class Iterable(WithDebugInfo):
+         self._operation_groups = tuple([
+             OperationGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._operations),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._operations)),
+                 owner=owner) for group_ir in ir.operation_groups
+         ])
+ 
+@@ -666,8 +671,9 @@ class Maplike(WithDebugInfo):
+         self._operation_groups = tuple([
+             OperationGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._operations),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._operations)),
+                 owner=owner) for group_ir in ir.operation_groups
+         ])
+ 
+@@ -755,8 +761,9 @@ class Setlike(WithDebugInfo):
+         self._operation_groups = tuple([
+             OperationGroup(
+                 group_ir,
+-                filter(lambda x: x.identifier == group_ir.identifier,
+-                       self._operations),
++                list(
++                    filter(lambda x: x.identifier == group_ir.identifier,
++                           self._operations)),
+                 owner=owner) for group_ir in ir.operation_groups
+         ])
+ 
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/ir_builder.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/ir_builder.py
+index e9aeff4ab82..d80554d603e 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/ir_builder.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/ir_builder.py
+@@ -2,6 +2,8 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import sys
++
+ from .argument import Argument
+ from .ast_group import AstGroup
+ from .attribute import Attribute
+@@ -30,6 +32,11 @@ from .operation import Operation
+ from .typedef import Typedef
+ 
+ 
++# TODO: Remove this once Python2 is obsoleted.
++if sys.version_info.major != 2:
++    long = int
++
++
+ def load_and_register_idl_definitions(filepaths, register_ir,
+                                       create_ref_to_idl_def, idl_type_factory):
+     """
+@@ -160,7 +167,7 @@ class _IRBuilder(object):
+         child_nodes = list(node.GetChildren())
+         extended_attributes = self._take_extended_attributes(child_nodes)
+ 
+-        members = map(self._build_interface_member, child_nodes)
++        members = list(map(self._build_interface_member, child_nodes))
+         attributes = []
+         constants = []
+         operations = []
+@@ -302,7 +309,7 @@ class _IRBuilder(object):
+         child_nodes = list(node.GetChildren())
+         inherited = self._take_inheritance(child_nodes)
+         extended_attributes = self._take_extended_attributes(child_nodes)
+-        own_members = map(self._build_dictionary_member, child_nodes)
++        own_members = list(map(self._build_dictionary_member, child_nodes))
+ 
+         return Dictionary.IR(
+             identifier=Identifier(node.GetName()),
+@@ -336,7 +343,7 @@ class _IRBuilder(object):
+ 
+         child_nodes = list(node.GetChildren())
+         extended_attributes = self._take_extended_attributes(child_nodes)
+-        members = map(self._build_interface_member, child_nodes)
++        members = list(map(self._build_interface_member, child_nodes))
+         constants = []
+         operations = []
+         for member in members:
+@@ -456,8 +463,8 @@ class _IRBuilder(object):
+                 assert len(child_nodes) == 1
+                 child = child_nodes[0]
+                 if child.GetClass() == 'Arguments':
+-                    arguments = map(build_extattr_argument,
+-                                    child.GetChildren())
++                    arguments = list(
++                        map(build_extattr_argument, child.GetChildren()))
+                 elif child.GetClass() == 'Call':
+                     assert len(child.GetChildren()) == 1
+                     grand_child = child.GetChildren()[0]
+@@ -486,7 +493,9 @@ class _IRBuilder(object):
+ 
+         assert node.GetClass() == 'ExtAttributes'
+         return ExtendedAttributes(
+-            filter(None, map(build_extended_attribute, node.GetChildren())))
++            list(
++                filter(None, map(build_extended_attribute,
++                                 node.GetChildren()))))
+ 
+     def _build_inheritance(self, node):
+         assert node.GetClass() == 'Inherit'
+@@ -506,7 +515,7 @@ class _IRBuilder(object):
+ 
+     def _build_iterable(self, node):
+         assert node.GetClass() == 'Iterable'
+-        types = map(self._build_type, node.GetChildren())
++        types = list(map(self._build_type, node.GetChildren()))
+         assert len(types) == 1 or len(types) == 2
+         if len(types) == 1:  # value iterator
+             key_type, value_type = (None, types[0])
+@@ -584,7 +593,7 @@ class _IRBuilder(object):
+     def _build_maplike(self, node, interface_identifier):
+         assert node.GetClass() == 'Maplike'
+         assert isinstance(interface_identifier, Identifier)
+-        types = map(self._build_type, node.GetChildren())
++        types = list(map(self._build_type, node.GetChildren()))
+         assert len(types) == 2
+         key_type, value_type = types
+         is_readonly = bool(node.GetProperty('READONLY'))
+@@ -676,7 +685,7 @@ class _IRBuilder(object):
+     def _build_setlike(self, node, interface_identifier):
+         assert node.GetClass() == 'Setlike'
+         assert isinstance(interface_identifier, Identifier)
+-        types = map(self._build_type, node.GetChildren())
++        types = list(map(self._build_type, node.GetChildren()))
+         assert len(types) == 1
+         value_type = types[0]
+         is_readonly = bool(node.GetProperty('READONLY'))
+@@ -838,7 +847,7 @@ class _IRBuilder(object):
+ 
+         def build_union_type(node, extended_attributes):
+             return self._idl_type_factory.union_type(
+-                member_types=map(self._build_type, node.GetChildren()),
++                member_types=list(map(self._build_type, node.GetChildren())),
+                 is_optional=is_optional,
+                 extended_attributes=extended_attributes,
+                 debug_info=self._build_debug_info(node))
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/make_copy.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/make_copy.py
+index a7a2b11f3f0..2f6b61300ff 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/make_copy.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/make_copy.py
+@@ -3,6 +3,13 @@
+ # found in the LICENSE file.
+ 
+ 
++import sys
++
++# TODO: Remove this once Python2 is obsoleted.
++if sys.version_info.major != 2:
++    long = int
++    basestring = str
++
+ def make_copy(obj, memo=None):
+     """
+     Creates a copy of the given object, which should be an IR or part of IR.
+diff --git a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/namespace.py b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/namespace.py
+index eeabef97cbe..bd7e98907f3 100644
+--- a/chromium/third_party/blink/renderer/bindings/scripts/web_idl/namespace.py
++++ b/chromium/third_party/blink/renderer/bindings/scripts/web_idl/namespace.py
+@@ -107,11 +107,13 @@ class Namespace(UserDefinedType, WithExtendedAttributes, WithCodeGeneratorInfo,
+             for operation_ir in ir.operations
+         ])
+         self._operation_groups = tuple([
+-            OperationGroup(
+-                operation_group_ir,
+-                filter(lambda x: x.identifier == operation_group_ir.identifier,
+-                       self._operations),
+-                owner=self) for operation_group_ir in ir.operation_groups
++            OperationGroup(operation_group_ir,
++                           list(
++                               filter(
++                                   lambda x: x.identifier == operation_group_ir
++                                   .identifier, self._operations)),
++                           owner=self)
++            for operation_group_ir in ir.operation_groups
+         ])
+ 
+     @property
+diff --git a/chromium/third_party/blink/renderer/bindings/templates/dictionary_v8.cc.tmpl b/chromium/third_party/blink/renderer/bindings/templates/dictionary_v8.cc.tmpl
+index 0add9c45a38..dc910f6d227 100644
+--- a/chromium/third_party/blink/renderer/bindings/templates/dictionary_v8.cc.tmpl
++++ b/chromium/third_party/blink/renderer/bindings/templates/dictionary_v8.cc.tmpl
+@@ -59,9 +59,9 @@ void {{v8_class}}::ToImpl(v8::Isolate* isolate, v8::Local<v8::Value> v8_value, {
+   DCHECK(executionContext);
+   {% endif %}{# has_origin_trial_members #}
+   {% endif %}{# members #}
+-  {% for origin_trial_test, origin_trial_member_list in members | groupby('origin_trial_feature_name') %}
++  {% for origin_trial_test, origin_trial_member_list in members | stringifykeygroupby('origin_trial_feature_name') %}
+   {% filter origin_trial_enabled(origin_trial_test, "executionContext") %}
+-  {% for feature_name, member_list in origin_trial_member_list | groupby('runtime_enabled_feature_name') %}
++  {% for feature_name, member_list in origin_trial_member_list | stringifykeygroupby('runtime_enabled_feature_name') %}
+   {% filter runtime_enabled(feature_name) %}
+   {% for member in member_list %}
+   v8::Local<v8::Value> {{member.v8_value}};
+@@ -147,9 +147,9 @@ bool toV8{{cpp_class}}(const {{cpp_class}}* impl, v8::Local<v8::Object> dictiona
+   DCHECK(executionContext);
+   {% endif %}{# has_origin_trial_members #}
+   {% endif %}{# members #}
+-  {% for origin_trial_test, origin_trial_member_list in members | groupby('origin_trial_feature_name') %}
++  {% for origin_trial_test, origin_trial_member_list in members | stringifykeygroupby('origin_trial_feature_name') %}
+   {% filter origin_trial_enabled(origin_trial_test, "executionContext") %}
+-  {% for feature_name, member_list in origin_trial_member_list | groupby('runtime_enabled_feature_name') %}
++  {% for feature_name, member_list in origin_trial_member_list | stringifykeygroupby('runtime_enabled_feature_name') %}
+   {% filter runtime_enabled(feature_name) %}
+   {% for member in member_list %}
+   v8::Local<v8::Value> {{member.v8_value}};
+diff --git a/chromium/third_party/blink/renderer/build/scripts/core/css/make_style_shorthands.py b/chromium/third_party/blink/renderer/build/scripts/core/css/make_style_shorthands.py
+index 1799cd5a153..5f43ffabc26 100755
+--- a/chromium/third_party/blink/renderer/build/scripts/core/css/make_style_shorthands.py
++++ b/chromium/third_party/blink/renderer/build/scripts/core/css/make_style_shorthands.py
+@@ -71,7 +71,7 @@ class Expansion(object):
+     def enabled_longhands(self):
+         include = lambda longhand: not longhand[
+             'runtime_flag'] or self.is_enabled(longhand['runtime_flag'])
+-        return filter(include, self._longhands)
++        return list(filter(include, self._longhands))
+ 
+     @property
+     def index(self):
+@@ -87,8 +87,9 @@ class Expansion(object):
+ 
+ def create_expansions(longhands):
+     flags = collect_runtime_flags(longhands)
+-    expansions = map(lambda mask: Expansion(longhands, flags, mask),
+-                     range(1 << len(flags)))
++    expansions = list(
++        map(lambda mask: Expansion(longhands, flags, mask),
++            range(1 << len(flags))))
+     assert len(expansions) > 0
+     # We generate 2^N expansions for N flags, so enforce some limit.
+     assert len(flags) <= 4, 'Too many runtime flags for a single shorthand'
+@@ -114,14 +115,14 @@ class StylePropertyShorthandWriter(json5_generator.Writer):
+ 
+         self._longhand_dictionary = defaultdict(list)
+         for property_ in json5_properties.shorthands:
+-            property_['longhand_enum_keys'] = map(enum_key_for_css_property,
+-                                                  property_['longhands'])
+-            property_['longhand_property_ids'] = map(id_for_css_property,
+-                                                     property_['longhands'])
+-
+-            longhands = map(
+-                lambda name: json5_properties.properties_by_name[name],
+-                property_['longhands'])
++            property_['longhand_enum_keys'] = list(
++                map(enum_key_for_css_property, property_['longhands']))
++            property_['longhand_property_ids'] = list(
++                map(id_for_css_property, property_['longhands']))
++
++            longhands = list(
++                map(lambda name: json5_properties.properties_by_name[name],
++                    property_['longhands']))
+             property_['expansions'] = create_expansions(longhands)
+             for longhand_enum_key in property_['longhand_enum_keys']:
+                 self._longhand_dictionary[longhand_enum_key].append(property_)
+diff --git a/chromium/third_party/blink/renderer/build/scripts/core/css/properties/make_css_property_instances.py b/chromium/third_party/blink/renderer/build/scripts/core/css/properties/make_css_property_instances.py
+index 75030ac577e..f72aadee17d 100755
+--- a/chromium/third_party/blink/renderer/build/scripts/core/css/properties/make_css_property_instances.py
++++ b/chromium/third_party/blink/renderer/build/scripts/core/css/properties/make_css_property_instances.py
+@@ -42,8 +42,8 @@ class CSSPropertyInstancesWriter(json5_generator.Writer):
+         aliases = self._css_properties.aliases
+ 
+         # Lists of PropertyClassData.
+-        self._property_classes_by_id = map(self.get_class, properties)
+-        self._alias_classes_by_id = map(self.get_class, aliases)
++        self._property_classes_by_id = list(map(self.get_class, properties))
++        self._alias_classes_by_id = list(map(self.get_class, aliases))
+ 
+         # Sort by enum value.
+         self._property_classes_by_id.sort(key=lambda t: t.enum_value)
+diff --git a/chromium/third_party/blink/renderer/build/scripts/gperf.py b/chromium/third_party/blink/renderer/build/scripts/gperf.py
+index 5ee49056be4..db72660d471 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/gperf.py
++++ b/chromium/third_party/blink/renderer/build/scripts/gperf.py
+@@ -95,7 +95,7 @@ def main():
+ 
+     open(args.output_file, 'wb').write(
+         generate_gperf(gperf_path,
+-                       open(infile).read(), gperf_args))
++                       open(infile).read(), gperf_args).encode('utf-8'))
+ 
+ 
+ if __name__ == '__main__':
+diff --git a/chromium/third_party/blink/renderer/build/scripts/in_file.py b/chromium/third_party/blink/renderer/build/scripts/in_file.py
+index 28adc050f1e..58113483e57 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/in_file.py
++++ b/chromium/third_party/blink/renderer/build/scripts/in_file.py
+@@ -66,7 +66,7 @@ class InFile(object):
+         self._defaults = defaults
+         self._valid_values = copy.deepcopy(
+             valid_values if valid_values else {})
+-        self._parse(map(str.strip, lines))
++        self._parse(list(map(str.strip, lines)))
+ 
+     @classmethod
+     def load_from_files(self, file_paths, defaults, valid_values,
+diff --git a/chromium/third_party/blink/renderer/build/scripts/in_generator.py b/chromium/third_party/blink/renderer/build/scripts/in_generator.py
+index e46740a2e85..ab1981ad1e3 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/in_generator.py
++++ b/chromium/third_party/blink/renderer/build/scripts/in_generator.py
+@@ -32,10 +32,15 @@ import os
+ import os.path
+ import shlex
+ import shutil
++import sys
+ import optparse
+ 
+ from in_file import InFile
+ 
++# TODO: Remove this once Python2 is obsoleted.
++if sys.version_info.major != 2:
++    basestring = str
++
+ 
+ #########################################################
+ # This is now deprecated - use json5_generator.py instead
+diff --git a/chromium/third_party/blink/renderer/build/scripts/make_runtime_features.py b/chromium/third_party/blink/renderer/build/scripts/make_runtime_features.py
+index cafe8d94a8e..6925a4fa580 100755
+--- a/chromium/third_party/blink/renderer/build/scripts/make_runtime_features.py
++++ b/chromium/third_party/blink/renderer/build/scripts/make_runtime_features.py
+@@ -138,7 +138,7 @@ class RuntimeFeatureWriter(BaseRuntimeFeatureWriter):
+                 except Exception:
+                     # If trouble unpickling, overwrite
+                     pass
+-        with open(os.path.abspath(file_name), 'w') as pickle_file:
++        with open(os.path.abspath(file_name), 'wb') as pickle_file:
+             pickle.dump(features_map, pickle_file)
+ 
+     def _template_inputs(self):
+diff --git a/chromium/third_party/blink/renderer/build/scripts/templates/element_factory.cc.tmpl b/chromium/third_party/blink/renderer/build/scripts/templates/element_factory.cc.tmpl
+index dc3f44c5b10..3eefcf9f0ee 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/templates/element_factory.cc.tmpl
++++ b/chromium/third_party/blink/renderer/build/scripts/templates/element_factory.cc.tmpl
+@@ -26,7 +26,7 @@ using {{namespace}}FunctionMap = HashMap<AtomicString, {{namespace}}ConstructorF
+ 
+ static {{namespace}}FunctionMap* g_{{namespace|lower}}_constructors = nullptr;
+ 
+-{% for tag in tags|sort if not tag.noConstructor %}
++{% for tag in tags|sort(attribute='name') if not tag.noConstructor %}
+ static {{namespace}}Element* {{namespace}}{{tag.name.to_upper_camel_case()}}Constructor(
+     Document& document, const CreateElementFlags flags) {
+   {% if tag.runtimeEnabled %}
+@@ -52,7 +52,7 @@ static void Create{{namespace}}FunctionMap() {
+   // Empty array initializer lists are illegal [dcl.init.aggr] and will not
+   // compile in MSVC. If tags list is empty, add check to skip this.
+   static const Create{{namespace}}FunctionMapData data[] = {
+-  {% for tag in tags|sort if not tag.noConstructor %}
++  {% for tag in tags|sort(attribute='name') if not tag.noConstructor %}
+     { {{cpp_namespace}}::{{tag|symbol}}Tag, {{namespace}}{{tag.name.to_upper_camel_case()}}Constructor },
+   {% endfor %}
+   };
+diff --git a/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.cc.tmpl b/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.cc.tmpl
+index 9bfc489e048..5f86184e879 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.cc.tmpl
++++ b/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.cc.tmpl
+@@ -22,7 +22,7 @@ HTMLTypeMap CreateHTMLTypeMap() {
+     const char* name;
+     HTMLElementType type;
+   } kTags[] = {
+-    {% for tag in tags|sort %}
++    {% for tag in tags|sort(attribute='name') %}
+     { "{{tag.name}}", HTMLElementType::k{{tag.js_interface}} },
+     {% endfor %}
+   };
+@@ -42,7 +42,7 @@ HTMLElementType htmlElementTypeForTag(const AtomicString& tagName, const Documen
+   if (it == html_type_map.end())
+     return HTMLElementType::kHTMLUnknownElement;
+ 
+-  {% for tag in tags|sort %}
++  {% for tag in tags|sort(attribute='name') %}
+   {% if tag.runtimeEnabled %}
+   if (tagName == "{{tag.name}}") {
+     if (!RuntimeEnabledFeatures::{{tag.runtimeEnabled}}Enabled(document->GetExecutionContext())) {
+diff --git a/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.h.tmpl b/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.h.tmpl
+index 1b5297d52dc..edecc81d9d4 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.h.tmpl
++++ b/chromium/third_party/blink/renderer/build/scripts/templates/element_type_helpers.h.tmpl
+@@ -15,7 +15,7 @@ namespace blink {
+ class Document;
+ 
+ // Type checking.
+-{% for tag in tags|sort if not tag.multipleTagNames and not tag.noTypeHelpers %}
++{% for tag in tags|sort(attribute='name') if not tag.multipleTagNames and not tag.noTypeHelpers %}
+ class {{tag.interface}};
+ template <>
+ inline bool IsElementOfType<const {{tag.interface}}>(const Node& node) {
+diff --git a/chromium/third_party/blink/renderer/build/scripts/templates/macros.tmpl b/chromium/third_party/blink/renderer/build/scripts/templates/macros.tmpl
+index 0244433af2e..dcdbb02a56c 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/templates/macros.tmpl
++++ b/chromium/third_party/blink/renderer/build/scripts/templates/macros.tmpl
+@@ -25,7 +25,7 @@
+ 
+ 
+ {% macro trie_leaf(index, object, return_macro, lowercase_data) %}
+-{% set name, value = object.items()[0] %}
++{% set name, value = (object.items()|list)[0] %}
+ {% if name|length %}
+ if (
+     {%- for c in name -%}
+@@ -45,7 +45,7 @@ return {{ return_macro(value) }};
+ 
+ 
+ {% macro trie_switch(trie, index, return_macro, lowercase_data) %}
+-{% if trie|length == 1 and trie.values()[0] is string %}
++{% if trie|length == 1 and (trie.values()|list)[0] is string %}
+ {{ trie_leaf(index, trie, return_macro, lowercase_data) -}}
+ {% else %}
+     {% if lowercase_data %}
+diff --git a/chromium/third_party/blink/renderer/build/scripts/templates/make_qualified_names.h.tmpl b/chromium/third_party/blink/renderer/build/scripts/templates/make_qualified_names.h.tmpl
+index cb05c6c4315..bd5566b03e7 100644
+--- a/chromium/third_party/blink/renderer/build/scripts/templates/make_qualified_names.h.tmpl
++++ b/chromium/third_party/blink/renderer/build/scripts/templates/make_qualified_names.h.tmpl
+@@ -24,12 +24,12 @@ namespace {{cpp_namespace}} {
+ {{symbol_export}}extern const WTF::AtomicString& {{namespace_prefix}}NamespaceURI;
+ 
+ // Tags
+-{% for tag in tags|sort %}
++{% for tag in tags|sort(attribute='name') %}
+ {{symbol_export}}extern const blink::{{namespace}}QualifiedName& {{tag|symbol}}Tag;
+ {% endfor %}
+ 
+ // Attributes
+-{% for attr in attrs|sort %}
++{% for attr in attrs|sort(attribute='name') %}
+ {{symbol_export}}extern const blink::QualifiedName& {{attr|symbol}}Attr;
+ {% endfor %}
+ 
+diff --git a/chromium/third_party/dawn/generator/generator_lib.py b/chromium/third_party/dawn/generator/generator_lib.py
+index 5e3734d7833..e3d46bd194f 100644
+--- a/chromium/third_party/dawn/generator/generator_lib.py
++++ b/chromium/third_party/dawn/generator/generator_lib.py
+@@ -201,6 +201,10 @@ def _compute_python_dependencies(root_dir=None):
+
+     paths = set()
+     for path in module_paths:
++        # Builtin/namespaced modules may return None for the file path.
++        if not path:
++            continue
++
+         path = os.path.abspath(path)
+
+         if not path.startswith(root_dir):
+diff --git a/chromium/third_party/devtools-frontend/src/BUILD.gn b/chromium/third_party/devtools-frontend/src/BUILD.gn
+index cd488e88b60..ea1dc3d9a79 100644
+--- a/chromium/third_party/devtools-frontend/src/BUILD.gn
++++ b/chromium/third_party/devtools-frontend/src/BUILD.gn
+@@ -2,6 +2,8 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/config/python.gni")
++
+ import("//third_party/blink/public/public_features.gni")
+ import("./all_devtools_files.gni")
+ import("./all_devtools_modules.gni")
+diff --git a/chromium/third_party/devtools-frontend/src/scripts/build/build_inspector_overlay.py b/chromium/third_party/devtools-frontend/src/scripts/build/build_inspector_overlay.py
+index d6666e8b74f..0f7a661e632 100644
+--- a/chromium/third_party/devtools-frontend/src/scripts/build/build_inspector_overlay.py
++++ b/chromium/third_party/devtools-frontend/src/scripts/build/build_inspector_overlay.py
+@@ -45,7 +45,8 @@ def rollup(input_path, output_path, filename, max_size, rollup_plugin):
+         ['--format', 'iife', '-n', 'InspectorOverlay'] + ['--input', target] +
+         ['--plugin', rollup_plugin],
+         stdout=subprocess.PIPE,
+-        stderr=subprocess.PIPE)
++        stderr=subprocess.PIPE,
++        text=True)
+     out, error = rollup_process.communicate()
+     if not out:
+         raise Exception("rollup failed: " + error)
+diff --git a/chromium/third_party/devtools-frontend/src/scripts/build/build_release_applications.py b/chromium/third_party/devtools-frontend/src/scripts/build/build_release_applications.py
+index fa8e73d34af..7d0b84b2171 100644
+--- a/chromium/third_party/devtools-frontend/src/scripts/build/build_release_applications.py
++++ b/chromium/third_party/devtools-frontend/src/scripts/build/build_release_applications.py
+@@ -10,7 +10,7 @@ Builds applications in release mode:
+ and the application loader into a single script.
+ """
+ 
+-from cStringIO import StringIO
++from io import StringIO
+ from os import path
+ from os.path import join
+ import copy
+@@ -145,8 +145,7 @@ class ReleaseBuilder(object):
+             resource_content = read_file(path.join(self.application_dir, resource_name))
+             if not (resource_name.endswith('.html')
+                     or resource_name.endswith('md')):
+-                resource_content += resource_source_url(resource_name).encode(
+-                    'utf-8')
++                resource_content += resource_source_url(resource_name)
+             resource_content = resource_content.replace('\\', '\\\\')
+             resource_content = resource_content.replace('\n', '\\n')
+             resource_content = resource_content.replace('"', '\\"')
+@@ -173,7 +172,9 @@ class ReleaseBuilder(object):
+     def _concatenate_application_script(self, output):
+         output.write('Root.allDescriptors.push(...%s);' % self._release_module_descriptors())
+         if self.descriptors.extends:
+-            output.write('Root.applicationDescriptor.modules.push(...%s);' % json.dumps(self.descriptors.application.values()))
++            output.write(
++                'Root.applicationDescriptor.modules.push(...%s);' %
++                json.dumps(list(self.descriptors.application.values())))
+         else:
+             output.write('Root.applicationDescriptor = %s;' % self.descriptors.application_json())
+ 
+diff --git a/chromium/third_party/devtools-frontend/src/scripts/build/generate_devtools_grd.py b/chromium/third_party/devtools-frontend/src/scripts/build/generate_devtools_grd.py
+index be510c48d76..c6a59c90298 100644
+--- a/chromium/third_party/devtools-frontend/src/scripts/build/generate_devtools_grd.py
++++ b/chromium/third_party/devtools-frontend/src/scripts/build/generate_devtools_grd.py
+@@ -123,7 +123,7 @@ def main(argv):
+ 
+     try:
+         os.makedirs(path.join(output_directory, 'Images'))
+-    except OSError, e:
++    except OSError as e:
+         if e.errno != errno.EEXIST:
+             raise e
+ 
+@@ -147,7 +147,7 @@ def main(argv):
+             shutil.copy(path.join(dirname, filename), path.join(output_directory, 'Images'))
+             add_file_to_grd(doc, path.join('Images', filename))
+ 
+-    with open(parsed_args.output_filename, 'w') as output_file:
++    with open(parsed_args.output_filename, 'wb') as output_file:
+         output_file.write(doc.toxml(encoding='UTF-8'))
+ 
+ 
+diff --git a/chromium/third_party/devtools-frontend/src/scripts/build/modular_build.py b/chromium/third_party/devtools-frontend/src/scripts/build/modular_build.py
+index 0ba695d3810..bb1da2f9f8d 100644
+--- a/chromium/third_party/devtools-frontend/src/scripts/build/modular_build.py
++++ b/chromium/third_party/devtools-frontend/src/scripts/build/modular_build.py
+@@ -7,6 +7,8 @@
+ Utilities for the modular DevTools build.
+ """
+ 
++from __future__ import print_function
++
+ import collections
+ from os import path
+ import os
+@@ -40,7 +42,7 @@ def load_and_parse_json(filename):
+     try:
+         return json.loads(read_file(filename))
+     except:
+-        print 'ERROR: Failed to parse %s' % filename
++        print('ERROR: Failed to parse %s' % filename)
+         raise
+ 
+ class Descriptors:
+@@ -57,7 +59,7 @@ class Descriptors:
+ 
+     def application_json(self):
+         result = dict()
+-        result['modules'] = self.application.values()
++        result['modules'] = list(self.application.values())
+         return json.dumps(result)
+ 
+     def all_compiled_files(self):
+diff --git a/chromium/third_party/jinja2/tests.py b/chromium/third_party/jinja2/tests.py
+index 0adc3d4dbcb..b14f85ff148 100644
+--- a/chromium/third_party/jinja2/tests.py
++++ b/chromium/third_party/jinja2/tests.py
+@@ -10,7 +10,7 @@
+ """
+ import operator
+ import re
+-from collections import Mapping
++from collections.abc import Mapping
+ from jinja2.runtime import Undefined
+ from jinja2._compat import text_type, string_types, integer_types
+ import decimal
+diff --git a/chromium/tools/metrics/ukm/gen_builders.py b/chromium/tools/metrics/ukm/gen_builders.py
+index f9f61d90a56..44e46fae8cc 100755
+--- a/chromium/tools/metrics/ukm/gen_builders.py
++++ b/chromium/tools/metrics/ukm/gen_builders.py
+@@ -48,9 +48,10 @@ def ReadFilteredData(path):
+     data = ukm_model.UKM_XML_TYPE.Parse(ukm_file.read())
+     event_tag = ukm_model._EVENT_TYPE.tag
+     metric_tag = ukm_model._METRIC_TYPE.tag
+-    data[event_tag] = filter(ukm_model.IsNotObsolete, data[event_tag])
++    data[event_tag] = list(filter(ukm_model.IsNotObsolete, data[event_tag]))
+     for event in data[event_tag]:
+-      event[metric_tag] = filter(ukm_model.IsNotObsolete, event[metric_tag])
++      event[metric_tag] = list(
++          filter(ukm_model.IsNotObsolete, event[metric_tag]))
+     return data
+ 
+ 
+diff --git a/chromium/ui/ozone/generate_constructor_list.py b/chromium/ui/ozone/generate_constructor_list.py
+index 8d800636c97..04fa18e93df 100755
+--- a/chromium/ui/ozone/generate_constructor_list.py
++++ b/chromium/ui/ozone/generate_constructor_list.py
+@@ -45,12 +45,15 @@ Example Output: ./ui/ozone/generate_constructor_list.py \
+   }  // namespace ui
+ """
+ 
++try:
++    from StringIO import StringIO  # for Python 2
++except ImportError:
++    from io import StringIO  # for Python 3
+ import optparse
+ import os
+ import collections
+ import re
+ import sys
+-import string
+ 
+ 
+ def GetTypedefName(typename):
+@@ -68,7 +71,7 @@ def GetConstructorName(typename, platform):
+   This is just "Create" + typename + platform.
+   """
+ 
+-  return 'Create' + typename + string.capitalize(platform)
++  return 'Create' + typename + platform.capitalize()
+ 
+ 
+ def GenerateConstructorList(out, namespace, export, typenames, platforms,
+@@ -163,12 +166,14 @@ def main(argv):
+     sys.exit(1)
+ 
+   # Write to standard output or file specified by --output_cc.
+-  out_cc = sys.stdout
++  out_cc = getattr(sys.stdout, 'buffer', sys.stdout)
+   if options.output_cc:
+     out_cc = open(options.output_cc, 'wb')
+ 
+-  GenerateConstructorList(out_cc, options.namespace, options.export,
++  out_cc_str = StringIO()
++  GenerateConstructorList(out_cc_str, options.namespace, options.export,
+                           typenames, platforms, includes, usings)
++  out_cc.write(out_cc_str.getvalue().encode('utf-8'))
+ 
+   if options.output_cc:
+     out_cc.close()
+diff --git a/chromium/ui/ozone/generate_ozone_platform_list.py b/chromium/ui/ozone/generate_ozone_platform_list.py
+index d47c398259b..2702b68b9bd 100755
+--- a/chromium/ui/ozone/generate_ozone_platform_list.py
++++ b/chromium/ui/ozone/generate_ozone_platform_list.py
+@@ -49,12 +49,15 @@ Example Output: ./generate_ozone_platform_list.py --default wayland dri wayland
+ 
+ """
+ 
++try:
++    from StringIO import StringIO  # for Python 2
++except ImportError:
++    from io import StringIO  # for Python 3
+ import optparse
+ import os
+ import collections
+ import re
+ import sys
+-import string
+ 
+ 
+ def GetConstantName(name):
+@@ -63,7 +66,7 @@ def GetConstantName(name):
+   We just capitalize the platform name and prepend "CreateOzonePlatform".
+   """
+ 
+-  return 'kPlatform' + string.capitalize(name)
++  return 'kPlatform' + name.capitalize()
+ 
+ 
+ def GeneratePlatformListText(out, platforms):
+@@ -149,9 +152,9 @@ def main(argv):
+     platforms.insert(0, options.default)
+ 
+   # Write to standard output or file specified by --output_{cc,h}.
+-  out_cc = sys.stdout
+-  out_h = sys.stdout
+-  out_txt = sys.stdout
++  out_cc = getattr(sys.stdout, 'buffer', sys.stdout)
++  out_h = getattr(sys.stdout, 'buffer', sys.stdout)
++  out_txt = getattr(sys.stdout, 'buffer', sys.stdout)
+   if options.output_cc:
+     out_cc = open(options.output_cc, 'wb')
+   if options.output_h:
+@@ -159,9 +162,16 @@ def main(argv):
+   if options.output_txt:
+     out_txt = open(options.output_txt, 'wb')
+ 
+-  GeneratePlatformListText(out_txt, platforms)
+-  GeneratePlatformListHeader(out_h, platforms)
+-  GeneratePlatformListSource(out_cc, platforms)
++  out_txt_str = StringIO()
++  out_h_str = StringIO()
++  out_cc_str = StringIO()
++
++  GeneratePlatformListText(out_txt_str, platforms)
++  out_txt.write(out_txt_str.getvalue().encode('utf-8'))
++  GeneratePlatformListHeader(out_h_str, platforms)
++  out_h.write(out_h_str.getvalue().encode('utf-8'))
++  GeneratePlatformListSource(out_cc_str, platforms)
++  out_cc.write(out_cc_str.getvalue().encode('utf-8'))
+ 
+   if options.output_cc:
+     out_cc.close()

--- a/qt5-webengine/qt5-webengine-ffmpeg5.patch
+++ b/qt5-webengine/qt5-webengine-ffmpeg5.patch
@@ -1,0 +1,150 @@
+diff --git a/chromium/media/ffmpeg/ffmpeg_common.h b/chromium/media/ffmpeg/ffmpeg_common.h
+index 2734a485cbd..70b1877a43c 100644
+--- a/chromium/media/ffmpeg/ffmpeg_common.h
++++ b/chromium/media/ffmpeg/ffmpeg_common.h
+@@ -29,6 +29,7 @@ extern "C" {
+ #include <libavformat/avformat.h>
+ #include <libavformat/avio.h>
+ #include <libavutil/avutil.h>
++#include <libavutil/channel_layout.h>
+ #include <libavutil/imgutils.h>
+ #include <libavutil/log.h>
+ #include <libavutil/mastering_display_metadata.h>
+diff --git a/chromium/media/filters/audio_file_reader.cc b/chromium/media/filters/audio_file_reader.cc
+index cb81d920def..bd73908d0ca 100644
+--- a/chromium/media/filters/audio_file_reader.cc
++++ b/chromium/media/filters/audio_file_reader.cc
+@@ -85,7 +85,7 @@ bool AudioFileReader::OpenDemuxer() {
+ }
+ 
+ bool AudioFileReader::OpenDecoder() {
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (codec) {
+     // MP3 decodes to S16P which we don't support, tell it to use S16 instead.
+     if (codec_context_->sample_fmt == AV_SAMPLE_FMT_S16P)
+diff --git a/chromium/media/filters/ffmpeg_audio_decoder.cc b/chromium/media/filters/ffmpeg_audio_decoder.cc
+index 0d825ed791b..72fac6167ef 100644
+--- a/chromium/media/filters/ffmpeg_audio_decoder.cc
++++ b/chromium/media/filters/ffmpeg_audio_decoder.cc
+@@ -329,7 +329,7 @@ bool FFmpegAudioDecoder::ConfigureDecoder(const AudioDecoderConfig& config) {
+     }
+   }
+ 
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (!codec ||
+       avcodec_open2(codec_context_.get(), codec, &codec_options) < 0) {
+     DLOG(ERROR) << "Could not initialize audio decoder: "
+diff --git a/chromium/media/filters/ffmpeg_demuxer.cc b/chromium/media/filters/ffmpeg_demuxer.cc
+index d34db63f3ef..427565b00c1 100644
+--- a/chromium/media/filters/ffmpeg_demuxer.cc
++++ b/chromium/media/filters/ffmpeg_demuxer.cc
+@@ -98,12 +98,12 @@ static base::TimeDelta ExtractStartTime(AVStream* stream) {
+ 
+   // Next try to use the first DTS value, for codecs where we know PTS == DTS
+   // (excludes all H26x codecs). The start time must be returned in PTS.
+-  if (stream->first_dts != kNoFFmpegTimestamp &&
++  if (av_stream_get_first_dts(stream) != kNoFFmpegTimestamp &&
+       stream->codecpar->codec_id != AV_CODEC_ID_HEVC &&
+       stream->codecpar->codec_id != AV_CODEC_ID_H264 &&
+       stream->codecpar->codec_id != AV_CODEC_ID_MPEG4) {
+     const base::TimeDelta first_pts =
+-        ConvertFromTimeBase(stream->time_base, stream->first_dts);
++        ConvertFromTimeBase(stream->time_base, av_stream_get_first_dts(stream));
+     if (first_pts < start_time)
+       start_time = first_pts;
+   }
+@@ -408,11 +408,11 @@ void FFmpegDemuxerStream::EnqueuePacket(ScopedAVPacket packet) {
+   scoped_refptr<DecoderBuffer> buffer;
+ 
+   if (type() == DemuxerStream::TEXT) {
+-    int id_size = 0;
++    size_t id_size = 0;
+     uint8_t* id_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_IDENTIFIER, &id_size);
+ 
+-    int settings_size = 0;
++    size_t settings_size = 0;
+     uint8_t* settings_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_WEBVTT_SETTINGS, &settings_size);
+ 
+@@ -424,7 +424,7 @@ void FFmpegDemuxerStream::EnqueuePacket(ScopedAVPacket packet) {
+     buffer = DecoderBuffer::CopyFrom(packet->data, packet->size,
+                                      side_data.data(), side_data.size());
+   } else {
+-    int side_data_size = 0;
++    size_t side_data_size = 0;
+     uint8_t* side_data = av_packet_get_side_data(
+         packet.get(), AV_PKT_DATA_MATROSKA_BLOCKADDITIONAL, &side_data_size);
+ 
+@@ -485,7 +485,7 @@ void FFmpegDemuxerStream::EnqueuePacket(ScopedAVPacket packet) {
+                                        packet->size - data_offset);
+     }
+ 
+-    int skip_samples_size = 0;
++    size_t skip_samples_size = 0;
+     const uint32_t* skip_samples_ptr =
+         reinterpret_cast<const uint32_t*>(av_packet_get_side_data(
+             packet.get(), AV_PKT_DATA_SKIP_SAMPLES, &skip_samples_size));
+diff --git a/chromium/media/filters/ffmpeg_glue.cc b/chromium/media/filters/ffmpeg_glue.cc
+index 0ef3521473d..8483ecc348f 100644
+--- a/chromium/media/filters/ffmpeg_glue.cc
++++ b/chromium/media/filters/ffmpeg_glue.cc
+@@ -59,7 +59,6 @@ static int64_t AVIOSeekOperation(void* opaque, int64_t offset, int whence) {
+ }
+ 
+ void FFmpegGlue::InitializeFFmpeg() {
+-  av_register_all();
+ }
+ 
+ static void LogContainer(bool is_local_file,
+@@ -95,9 +94,6 @@ FFmpegGlue::FFmpegGlue(FFmpegURLProtocol* protocol) {
+   // Enable fast, but inaccurate seeks for MP3.
+   format_context_->flags |= AVFMT_FLAG_FAST_SEEK;
+ 
+-  // Ensures we can read out various metadata bits like vp8 alpha.
+-  format_context_->flags |= AVFMT_FLAG_KEEP_SIDE_DATA;
+-
+   // Ensures format parsing errors will bail out. From an audit on 11/2017, all
+   // instances were real failures. Solves bugs like http://crbug.com/710791.
+   format_context_->error_recognition |= AV_EF_EXPLODE;
+diff --git a/chromium/media/filters/ffmpeg_video_decoder.cc b/chromium/media/filters/ffmpeg_video_decoder.cc
+index ef12477ee89..7996606f5f9 100644
+--- a/chromium/media/filters/ffmpeg_video_decoder.cc
++++ b/chromium/media/filters/ffmpeg_video_decoder.cc
+@@ -391,7 +391,7 @@ bool FFmpegVideoDecoder::ConfigureDecoder(const VideoDecoderConfig& config,
+   if (decode_nalus_)
+     codec_context_->flags2 |= AV_CODEC_FLAG2_CHUNKS;
+ 
+-  AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(codec_context_->codec_id);
+   if (!codec || avcodec_open2(codec_context_.get(), codec, NULL) < 0) {
+     ReleaseFFmpegResources();
+     return false;
+diff --git a/chromium/media/filters/media_file_checker.cc b/chromium/media/filters/media_file_checker.cc
+index 59c2a2fc618..1a9872c7acb 100644
+--- a/chromium/media/filters/media_file_checker.cc
++++ b/chromium/media/filters/media_file_checker.cc
+@@ -68,7 +68,7 @@ bool MediaFileChecker::Start(base::TimeDelta check_time) {
+       auto context = AVStreamToAVCodecContext(format_context->streams[i]);
+       if (!context)
+         continue;
+-      AVCodec* codec = avcodec_find_decoder(cp->codec_id);
++      const AVCodec* codec = avcodec_find_decoder(cp->codec_id);
+       if (codec && avcodec_open2(context.get(), codec, nullptr) >= 0) {
+         auto loop = std::make_unique<FFmpegDecodingLoop>(context.get());
+         stream_contexts[i] = {std::move(context), std::move(loop)};
+diff --git a/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc b/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc
+index 9002b874611..d12fade8b63 100644
+--- a/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc
++++ b/chromium/third_party/webrtc/modules/video_coding/codecs/h264/h264_decoder_impl.cc
+@@ -203,7 +203,7 @@ int32_t H264DecoderImpl::InitDecode(const VideoCodec* codec_settings,
+   // a pointer |this|.
+   av_context_->opaque = this;
+ 
+-  AVCodec* codec = avcodec_find_decoder(av_context_->codec_id);
++  const AVCodec* codec = avcodec_find_decoder(av_context_->codec_id);
+   if (!codec) {
+     // This is an indication that FFmpeg has not been initialized or it has not
+     // been compiled/initialized with the correct set of codecs.

--- a/qt5-webengine/qt5-webengine-gcc12.patch
+++ b/qt5-webengine/qt5-webengine-gcc12.patch
@@ -1,0 +1,13 @@
+diff --git a/chromium/third_party/skia/src/utils/SkParseColor.cpp b/chromium/third_party/skia/src/utils/SkParseColor.cpp
+index 7260365b2c6..b5a6aae3596 100644
+--- a/chromium/third_party/skia/src/utils/SkParseColor.cpp
++++ b/chromium/third_party/skia/src/utils/SkParseColor.cpp
+@@ -8,6 +8,8 @@
+ 
+ #include "include/utils/SkParse.h"
+ 
++#include <iterator>
++
+ static constexpr const char* gColorNames[] = {
+     "aliceblue",
+     "antiquewhite",

--- a/qt5-webengine/qt5-webengine-glibc-2.33.patch
+++ b/qt5-webengine/qt5-webengine-glibc-2.33.patch
@@ -1,0 +1,144 @@
+# Patch made by Kevin Kofler <Kevin@tigcc.ticalc.org>
+# https://bugzilla.redhat.com/show_bug.cgi?id=1904652
+
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2021-01-20 02:14:53.066223906 +0100
+@@ -257,6 +257,18 @@
+     return RestrictKillTarget(current_pid, sysno);
+   }
+ 
++#if defined(__NR_newfstatat)
++  if (sysno == __NR_newfstatat) {
++    return RewriteFstatatSIGSYS();
++  }
++#endif
++
++#if defined(__NR_fstatat64)
++  if (sysno == __NR_fstatat64) {
++    return RewriteFstatatSIGSYS();
++  }
++#endif
++
+   if (SyscallSets::IsFileSystem(sysno) ||
+       SyscallSets::IsCurrentDirectory(sysno)) {
+     return Error(fs_denied_errno);
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2021-01-22 19:02:55.651668257 +0100
+@@ -6,6 +6,8 @@
+ 
+ #include "sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h"
+ 
++#include <errno.h>
++#include <fcntl.h>
+ #include <stddef.h>
+ #include <stdint.h>
+ #include <string.h>
+@@ -355,6 +357,35 @@
+   return -ENOSYS;
+ }
+ 
++intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
++                            void* aux) {
++  switch (args.nr) {
++#if defined(__NR_newfstatat)
++    case __NR_newfstatat:
++#endif
++#if defined(__NR_fstatat64)
++    case __NR_fstatat64:
++#endif
++#if defined(__NR_newfstatat) || defined(__NR_fstatat64)
++      if (*reinterpret_cast<const char *>(args.args[1]) == '\0'
++          && args.args[3] == static_cast<uint64_t>(AT_EMPTY_PATH)) {
++        return sandbox::sys_fstat64(static_cast<int>(args.args[0]),
++                                    reinterpret_cast<struct stat64 *>(args.args[2]));
++      } else {
++        errno = EACCES;
++        return -1;
++      }
++      break;
++#endif
++  }
++
++  CrashSIGSYS_Handler(args, aux);
++
++  // Should never be reached.
++  RAW_CHECK(false);
++  return -ENOSYS;
++}
++
+ bpf_dsl::ResultExpr CrashSIGSYS() {
+   return bpf_dsl::Trap(CrashSIGSYS_Handler, NULL);
+ }
+@@ -387,6 +418,10 @@
+   return bpf_dsl::Trap(SIGSYSSchedHandler, NULL);
+ }
+ 
++bpf_dsl::ResultExpr RewriteFstatatSIGSYS() {
++  return bpf_dsl::Trap(SIGSYSFstatatHandler, NULL);
++}
++
+ void AllocateCrashKeys() {
+ #if !defined(OS_NACL_NONSFI)
+   if (seccomp_crash_key)
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.h	2021-01-20 02:11:04.583714199 +0100
+@@ -62,6 +62,10 @@
+ // sched_setparam(), sched_setscheduler()
+ SANDBOX_EXPORT intptr_t SIGSYSSchedHandler(const arch_seccomp_data& args,
+                                            void* aux);
++// If the fstatat syscall is actually a disguised fstat, calls the regular fstat
++// syscall, otherwise, crashes in the same way as CrashSIGSYS_Handler.
++SANDBOX_EXPORT intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args, 
++                                             void* aux);
+ 
+ // Variants of the above functions for use with bpf_dsl.
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYS();
+@@ -72,6 +76,7 @@
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYSFutex();
+ SANDBOX_EXPORT bpf_dsl::ResultExpr CrashSIGSYSPtrace();
+ SANDBOX_EXPORT bpf_dsl::ResultExpr RewriteSchedSIGSYS();
++SANDBOX_EXPORT bpf_dsl::ResultExpr RewriteFstatatSIGSYS();
+ 
+ // Allocates a crash key so that Seccomp information can be recorded.
+ void AllocateCrashKeys();
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.cc	2021-01-20 02:41:12.033133269 +0100
+@@ -261,4 +261,13 @@
+ 
+ #endif  // defined(MEMORY_SANITIZER)
+ 
++SANDBOX_EXPORT int sys_fstat64(int fd, struct stat64 *buf)
++{
++#if defined(__NR_fstat64)
++    return syscall(__NR_fstat64, fd, buf);
++#else
++    return syscall(__NR_fstat, fd, buf);
++#endif
++}
++
+ }  // namespace sandbox
+diff -ur qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h
+--- qtwebengine-everywhere-src-5.15.2/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2020-11-07 02:22:36.000000000 +0100
++++ qtwebengine-everywhere-src-5.15.2-#1904652/src/3rdparty/chromium/sandbox/linux/services/syscall_wrappers.h	2021-01-20 02:40:26.499827829 +0100
+@@ -17,6 +17,7 @@
+ struct rlimit64;
+ struct cap_hdr;
+ struct cap_data;
++struct stat64;
+ 
+ namespace sandbox {
+ 
+@@ -84,6 +85,9 @@
+                                  const struct sigaction* act,
+                                  struct sigaction* oldact);
+ 
++// Recent glibc rewrites fstat to fstatat.
++SANDBOX_EXPORT int sys_fstat64(int fd, struct stat64 *buf);
++
+ }  // namespace sandbox
+ 
+ #endif  // SANDBOX_LINUX_SERVICES_SYSCALL_WRAPPERS_H_

--- a/qt5-webengine/qt5-webengine-pipewire-0.3.patch
+++ b/qt5-webengine/qt5-webengine-pipewire-0.3.patch
@@ -1,0 +1,1819 @@
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/BUILD.gn b/chromium/third_party/webrtc/modules/desktop_capture/BUILD.gn
+index 5235512735d..8259442f811 100644
+--- a/chromium/third_party/webrtc/modules/desktop_capture/BUILD.gn
++++ b/chromium/third_party/webrtc/modules/desktop_capture/BUILD.gn
+@@ -11,6 +11,11 @@ import("//build/config/ui.gni")
+ import("//tools/generate_stubs/rules.gni")
+ import("../../webrtc.gni")
+ 
++if (rtc_use_pipewire) {
++  assert(rtc_pipewire_version == "0.2" || rtc_pipewire_version == "0.3",
++         "Unsupported PipeWire version")
++}
++
+ use_desktop_capture_differ_sse2 = current_cpu == "x86" || current_cpu == "x64"
+ 
+ config("x11_config") {
+@@ -200,22 +205,41 @@ if (is_linux || is_chromeos) {
+       ]
+     }
+ 
+-    if (rtc_link_pipewire) {
++    if (rtc_pipewire_version == "0.3") {
+       pkg_config("pipewire") {
+-        packages = [ "libpipewire-0.2" ]
++        packages = [ "libpipewire-0.3" ]
++        if (!rtc_link_pipewire) {
++          ignore_libs = true
++        }
+       }
+     } else {
++      pkg_config("pipewire") {
++        packages = [ "libpipewire-0.2" ]
++        if (!rtc_link_pipewire) {
++          ignore_libs = true
++        }
++      }
++    }
++
++    if (!rtc_link_pipewire) {
+       # When libpipewire is not directly linked, use stubs to allow for dlopening of
+       # the binary.
+       generate_stubs("pipewire_stubs") {
+-        configs = [ "../../:common_config" ]
++        configs = [
++          "../../:common_config",
++          ":pipewire",
++        ]
+         deps = [ "../../rtc_base" ]
+         extra_header = "linux/pipewire_stub_header.fragment"
+         logging_function = "RTC_LOG(LS_VERBOSE)"
+         logging_include = "rtc_base/logging.h"
+         output_name = "linux/pipewire_stubs"
+         path_from_source = "modules/desktop_capture/linux"
+-        sigs = [ "linux/pipewire.sigs" ]
++        if (rtc_pipewire_version == "0.3") {
++          sigs = [ "linux/pipewire03.sigs" ]
++        } else {
++          sigs = [ "linux/pipewire02.sigs" ]
++        }
+       }
+     }
+ 
+@@ -506,6 +530,7 @@ rtc_library("desktop_capture_generic") {
+   absl_deps = [
+     "//third_party/abseil-cpp/absl/memory",
+     "//third_party/abseil-cpp/absl/strings",
++    "//third_party/abseil-cpp/absl/types:optional",
+   ]
+ 
+   if (rtc_use_x11_extensions) {
+@@ -526,20 +551,15 @@ rtc_library("desktop_capture_generic") {
+     sources += [
+       "linux/base_capturer_pipewire.cc",
+       "linux/base_capturer_pipewire.h",
+-      "linux/screen_capturer_pipewire.cc",
+-      "linux/screen_capturer_pipewire.h",
+-      "linux/window_capturer_pipewire.cc",
+-      "linux/window_capturer_pipewire.h",
+     ]
+ 
+     configs += [
+       ":pipewire_config",
+       ":gio",
++      ":pipewire",
+     ]
+ 
+-    if (rtc_link_pipewire) {
+-      configs += [ ":pipewire" ]
+-    } else {
++    if (!rtc_link_pipewire) {
+       deps += [ ":pipewire_stubs" ]
+     }
+   }
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.cc b/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.cc
+index 2640e93aa98..c302a086ead 100644
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.cc
++++ b/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.cc
+@@ -14,8 +14,14 @@
+ #include <glib-object.h>
+ #include <spa/param/format-utils.h>
+ #include <spa/param/props.h>
++#if !PW_CHECK_VERSION(0, 3, 0)
+ #include <spa/param/video/raw-utils.h>
+ #include <spa/support/type-map.h>
++#endif
++
++#include <sys/ioctl.h>
++#include <sys/mman.h>
++#include <sys/syscall.h>
+ 
+ #include <memory>
+ #include <utility>
+@@ -30,7 +36,11 @@
+ #include "modules/desktop_capture/linux/pipewire_stubs.h"
+ 
+ using modules_desktop_capture_linux::InitializeStubs;
+-using modules_desktop_capture_linux::kModulePipewire;
++#if PW_CHECK_VERSION(0, 3, 0)
++using modules_desktop_capture_linux::kModulePipewire03;
++#else
++using modules_desktop_capture_linux::kModulePipewire02;
++#endif
+ using modules_desktop_capture_linux::StubPathMap;
+ #endif  // defined(WEBRTC_DLOPEN_PIPEWIRE)
+ 
+@@ -47,9 +57,156 @@ const char kScreenCastInterfaceName[] = "org.freedesktop.portal.ScreenCast";
+ const int kBytesPerPixel = 4;
+ 
+ #if defined(WEBRTC_DLOPEN_PIPEWIRE)
++#if PW_CHECK_VERSION(0, 3, 0)
++const char kPipeWireLib[] = "libpipewire-0.3.so.0";
++#else
+ const char kPipeWireLib[] = "libpipewire-0.2.so.1";
+ #endif
++#endif
+ 
++// static
++struct dma_buf_sync {
++  uint64_t flags;
++};
++#define DMA_BUF_SYNC_READ (1 << 0)
++#define DMA_BUF_SYNC_START (0 << 2)
++#define DMA_BUF_SYNC_END (1 << 2)
++#define DMA_BUF_BASE 'b'
++#define DMA_BUF_IOCTL_SYNC _IOW(DMA_BUF_BASE, 0, struct dma_buf_sync)
++
++static void SyncDmaBuf(int fd, uint64_t start_or_end) {
++  struct dma_buf_sync sync = {0};
++
++  sync.flags = start_or_end | DMA_BUF_SYNC_READ;
++
++  while (true) {
++    int ret;
++    ret = ioctl(fd, DMA_BUF_IOCTL_SYNC, &sync);
++    if (ret == -1 && errno == EINTR) {
++      continue;
++    } else if (ret == -1) {
++      RTC_LOG(LS_ERROR) << "Failed to synchronize DMA buffer: "
++                        << g_strerror(errno);
++      break;
++    } else {
++      break;
++    }
++  }
++}
++
++class ScopedBuf {
++ public:
++  ScopedBuf() {}
++  ScopedBuf(unsigned char* map, int map_size, bool is_dma_buf, int fd)
++      : map_(map), map_size_(map_size), is_dma_buf_(is_dma_buf), fd_(fd) {}
++  ~ScopedBuf() {
++    if (map_ != MAP_FAILED) {
++      if (is_dma_buf_) {
++        SyncDmaBuf(fd_, DMA_BUF_SYNC_END);
++      }
++      munmap(map_, map_size_);
++    }
++  }
++
++  operator bool() { return map_ != MAP_FAILED; }
++
++  void initialize(unsigned char* map, int map_size, bool is_dma_buf, int fd) {
++    map_ = map;
++    map_size_ = map_size;
++    is_dma_buf_ = is_dma_buf;
++    fd_ = fd;
++  }
++
++  unsigned char* get() { return map_; }
++
++ protected:
++  unsigned char* map_ = nullptr;
++  int map_size_;
++  bool is_dma_buf_;
++  int fd_;
++};
++
++template <class T>
++class Scoped {
++ public:
++  Scoped() {}
++  explicit Scoped(T* val) { ptr_ = val; }
++  ~Scoped() { RTC_NOTREACHED(); }
++
++  T* operator->() { return ptr_; }
++
++  bool operator!() { return ptr_ == nullptr; }
++
++  T* get() { return ptr_; }
++
++  T** receive() {
++    RTC_CHECK(!ptr_);
++    return &ptr_;
++  }
++
++  Scoped& operator=(T* val) {
++    ptr_ = val;
++    return *this;
++  }
++
++ protected:
++  T* ptr_ = nullptr;
++};
++
++template <>
++Scoped<GError>::~Scoped() {
++  if (ptr_) {
++    g_error_free(ptr_);
++  }
++}
++
++template <>
++Scoped<gchar>::~Scoped() {
++  if (ptr_) {
++    g_free(ptr_);
++  }
++}
++
++template <>
++Scoped<GVariant>::~Scoped() {
++  if (ptr_) {
++    g_variant_unref(ptr_);
++  }
++}
++
++template <>
++Scoped<GVariantIter>::~Scoped() {
++  if (ptr_) {
++    g_variant_iter_free(ptr_);
++  }
++}
++
++template <>
++Scoped<GDBusMessage>::~Scoped() {
++  if (ptr_) {
++    g_object_unref(ptr_);
++  }
++}
++
++template <>
++Scoped<GUnixFDList>::~Scoped() {
++  if (ptr_) {
++    g_object_unref(ptr_);
++  }
++}
++
++#if PW_CHECK_VERSION(0, 3, 0)
++void BaseCapturerPipeWire::OnCoreError(void* data,
++                                       uint32_t id,
++                                       int seq,
++                                       int res,
++                                       const char* message) {
++  BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(data);
++  RTC_DCHECK(that);
++
++  RTC_LOG(LS_ERROR) << "PipeWire remote error: " << message;
++}
++#else
+ // static
+ void BaseCapturerPipeWire::OnStateChanged(void* data,
+                                           pw_remote_state old_state,
+@@ -64,7 +221,7 @@ void BaseCapturerPipeWire::OnStateChanged(void* data,
+       break;
+     case PW_REMOTE_STATE_CONNECTED:
+       RTC_LOG(LS_INFO) << "PipeWire remote state: connected.";
+-      that->CreateReceivingStream();
++      that->pw_stream_ = that->CreateReceivingStream();
+       break;
+     case PW_REMOTE_STATE_CONNECTING:
+       RTC_LOG(LS_INFO) << "PipeWire remote state: connecting.";
+@@ -74,6 +231,7 @@ void BaseCapturerPipeWire::OnStateChanged(void* data,
+       break;
+   }
+ }
++#endif
+ 
+ // static
+ void BaseCapturerPipeWire::OnStreamStateChanged(void* data,
+@@ -83,6 +241,18 @@ void BaseCapturerPipeWire::OnStreamStateChanged(void* data,
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(data);
+   RTC_DCHECK(that);
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  switch (state) {
++    case PW_STREAM_STATE_ERROR:
++      RTC_LOG(LS_ERROR) << "PipeWire stream state error: " << error_message;
++      break;
++    case PW_STREAM_STATE_PAUSED:
++    case PW_STREAM_STATE_STREAMING:
++    case PW_STREAM_STATE_UNCONNECTED:
++    case PW_STREAM_STATE_CONNECTING:
++      break;
++  }
++#else
+   switch (state) {
+     case PW_STREAM_STATE_ERROR:
+       RTC_LOG(LS_ERROR) << "PipeWire stream state error: " << error_message;
+@@ -97,36 +267,74 @@ void BaseCapturerPipeWire::OnStreamStateChanged(void* data,
+     case PW_STREAM_STATE_STREAMING:
+       break;
+   }
++#endif
+ }
+ 
+ // static
++#if PW_CHECK_VERSION(0, 3, 0)
++void BaseCapturerPipeWire::OnStreamParamChanged(void* data,
++                                                uint32_t id,
++                                                const struct spa_pod* format) {
++#else
+ void BaseCapturerPipeWire::OnStreamFormatChanged(void* data,
+                                                  const struct spa_pod* format) {
++#endif
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(data);
+   RTC_DCHECK(that);
+ 
+   RTC_LOG(LS_INFO) << "PipeWire stream format changed.";
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (!format || id != SPA_PARAM_Format) {
++#else
+   if (!format) {
+     pw_stream_finish_format(that->pw_stream_, /*res=*/0, /*params=*/nullptr,
+                             /*n_params=*/0);
++#endif
+     return;
+   }
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  spa_format_video_raw_parse(format, &that->spa_video_format_);
++#else
+   that->spa_video_format_ = new spa_video_info_raw();
+   spa_format_video_raw_parse(format, that->spa_video_format_,
+                              &that->pw_type_->format_video);
++#endif
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  auto width = that->spa_video_format_.size.width;
++  auto height = that->spa_video_format_.size.height;
++#else
+   auto width = that->spa_video_format_->size.width;
+   auto height = that->spa_video_format_->size.height;
++#endif
+   auto stride = SPA_ROUND_UP_N(width * kBytesPerPixel, 4);
+   auto size = height * stride;
+ 
++  that->desktop_size_ = DesktopSize(width, height);
++
+   uint8_t buffer[1024] = {};
+   auto builder = spa_pod_builder{buffer, sizeof(buffer)};
+ 
+   // Setup buffers and meta header for new format.
+-  const struct spa_pod* params[2];
++  const struct spa_pod* params[3];
++#if PW_CHECK_VERSION(0, 3, 0)
++  params[0] = reinterpret_cast<spa_pod*>(spa_pod_builder_add_object(
++      &builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
++      SPA_PARAM_BUFFERS_size, SPA_POD_Int(size), SPA_PARAM_BUFFERS_stride,
++      SPA_POD_Int(stride), SPA_PARAM_BUFFERS_buffers,
++      SPA_POD_CHOICE_RANGE_Int(8, 1, 32)));
++  params[1] = reinterpret_cast<spa_pod*>(spa_pod_builder_add_object(
++      &builder, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
++      SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size,
++      SPA_POD_Int(sizeof(struct spa_meta_header))));
++  params[2] = reinterpret_cast<spa_pod*>(spa_pod_builder_add_object(
++      &builder, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type,
++      SPA_POD_Id(SPA_META_VideoCrop), SPA_PARAM_META_size,
++      SPA_POD_Int(sizeof(struct spa_meta_region))));
++  pw_stream_update_params(that->pw_stream_, params, 3);
++#else
+   params[0] = reinterpret_cast<spa_pod*>(spa_pod_builder_object(
+       &builder,
+       // id to enumerate buffer requirements
+@@ -155,8 +363,18 @@ void BaseCapturerPipeWire::OnStreamFormatChanged(void* data,
+       // Size: size of the metadata, specified as integer (i)
+       ":", that->pw_core_type_->param_meta.size, "i",
+       sizeof(struct spa_meta_header)));
+-
+-  pw_stream_finish_format(that->pw_stream_, /*res=*/0, params, /*n_params=*/2);
++  params[2] = reinterpret_cast<spa_pod*>(spa_pod_builder_object(
++      &builder,
++      // id to enumerate supported metadata
++      that->pw_core_type_->param.idMeta, that->pw_core_type_->param_meta.Meta,
++      // Type: specified as id or enum (I)
++      ":", that->pw_core_type_->param_meta.type, "I",
++      that->pw_core_type_->meta.VideoCrop,
++      // Size: size of the metadata, specified as integer (i)
++      ":", that->pw_core_type_->param_meta.size, "i",
++      sizeof(struct spa_meta_video_crop)));
++  pw_stream_finish_format(that->pw_stream_, /*res=*/0, params, /*n_params=*/3);
++#endif
+ }
+ 
+ // static
+@@ -164,15 +382,26 @@ void BaseCapturerPipeWire::OnStreamProcess(void* data) {
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(data);
+   RTC_DCHECK(that);
+ 
+-  pw_buffer* buf = nullptr;
++  struct pw_buffer* next_buffer;
++  struct pw_buffer* buffer = nullptr;
++
++  next_buffer = pw_stream_dequeue_buffer(that->pw_stream_);
++  while (next_buffer) {
++    buffer = next_buffer;
++    next_buffer = pw_stream_dequeue_buffer(that->pw_stream_);
+ 
+-  if (!(buf = pw_stream_dequeue_buffer(that->pw_stream_))) {
++    if (next_buffer) {
++      pw_stream_queue_buffer(that->pw_stream_, buffer);
++    }
++  }
++
++  if (!buffer) {
+     return;
+   }
+ 
+-  that->HandleBuffer(buf);
++  that->HandleBuffer(buffer);
+ 
+-  pw_stream_queue_buffer(that->pw_stream_, buf);
++  pw_stream_queue_buffer(that->pw_stream_, buffer);
+ }
+ 
+ BaseCapturerPipeWire::BaseCapturerPipeWire(CaptureSourceType source_type)
+@@ -183,6 +412,7 @@ BaseCapturerPipeWire::~BaseCapturerPipeWire() {
+     pw_thread_loop_stop(pw_main_loop_);
+   }
+ 
++#if !PW_CHECK_VERSION(0, 3, 0)
+   if (pw_type_) {
+     delete pw_type_;
+   }
+@@ -190,30 +420,41 @@ BaseCapturerPipeWire::~BaseCapturerPipeWire() {
+   if (spa_video_format_) {
+     delete spa_video_format_;
+   }
++#endif
+ 
+   if (pw_stream_) {
+     pw_stream_destroy(pw_stream_);
+   }
+ 
++#if !PW_CHECK_VERSION(0, 3, 0)
+   if (pw_remote_) {
+     pw_remote_destroy(pw_remote_);
+   }
++#endif
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (pw_core_) {
++    pw_core_disconnect(pw_core_);
++  }
++
++  if (pw_context_) {
++    pw_context_destroy(pw_context_);
++  }
++#else
+   if (pw_core_) {
+     pw_core_destroy(pw_core_);
+   }
++#endif
+ 
+   if (pw_main_loop_) {
+     pw_thread_loop_destroy(pw_main_loop_);
+   }
+ 
++#if !PW_CHECK_VERSION(0, 3, 0)
+   if (pw_loop_) {
+     pw_loop_destroy(pw_loop_);
+   }
+-
+-  if (current_frame_) {
+-    free(current_frame_);
+-  }
++#endif
+ 
+   if (start_request_signal_id_) {
+     g_dbus_connection_signal_unsubscribe(connection_, start_request_signal_id_);
+@@ -228,18 +469,16 @@ BaseCapturerPipeWire::~BaseCapturerPipeWire() {
+   }
+ 
+   if (session_handle_) {
+-    GDBusMessage* message = g_dbus_message_new_method_call(
+-        kDesktopBusName, session_handle_, kSessionInterfaceName, "Close");
+-    if (message) {
+-      GError* error = nullptr;
+-      g_dbus_connection_send_message(connection_, message,
++    Scoped<GDBusMessage> message(g_dbus_message_new_method_call(
++        kDesktopBusName, session_handle_, kSessionInterfaceName, "Close"));
++    if (message.get()) {
++      Scoped<GError> error;
++      g_dbus_connection_send_message(connection_, message.get(),
+                                      G_DBUS_SEND_MESSAGE_FLAGS_NONE,
+-                                     /*out_serial=*/nullptr, &error);
+-      if (error) {
++                                     /*out_serial=*/nullptr, error.receive());
++      if (error.get()) {
+         RTC_LOG(LS_ERROR) << "Failed to close the session: " << error->message;
+-        g_error_free(error);
+       }
+-      g_object_unref(message);
+     }
+   }
+ 
+@@ -274,7 +513,11 @@ void BaseCapturerPipeWire::InitPipeWire() {
+   StubPathMap paths;
+ 
+   // Check if the PipeWire library is available.
+-  paths[kModulePipewire].push_back(kPipeWireLib);
++#if PW_CHECK_VERSION(0, 3, 0)
++  paths[kModulePipewire03].push_back(kPipeWireLib);
++#else
++  paths[kModulePipewire02].push_back(kPipeWireLib);
++#endif
+   if (!InitializeStubs(paths)) {
+     RTC_LOG(LS_ERROR) << "Failed to load the PipeWire library and symbols.";
+     portal_init_failed_ = true;
+@@ -284,16 +527,46 @@ void BaseCapturerPipeWire::InitPipeWire() {
+ 
+   pw_init(/*argc=*/nullptr, /*argc=*/nullptr);
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  pw_main_loop_ = pw_thread_loop_new("pipewire-main-loop", nullptr);
++
++  pw_thread_loop_lock(pw_main_loop_);
++
++  pw_context_ =
++      pw_context_new(pw_thread_loop_get_loop(pw_main_loop_), nullptr, 0);
++  if (!pw_context_) {
++    RTC_LOG(LS_ERROR) << "Failed to create PipeWire context";
++    return;
++  }
++
++  pw_core_ = pw_context_connect(pw_context_, nullptr, 0);
++  if (!pw_core_) {
++    RTC_LOG(LS_ERROR) << "Failed to connect PipeWire context";
++    return;
++  }
++#else
+   pw_loop_ = pw_loop_new(/*properties=*/nullptr);
+   pw_main_loop_ = pw_thread_loop_new(pw_loop_, "pipewire-main-loop");
+ 
++  pw_thread_loop_lock(pw_main_loop_);
++
+   pw_core_ = pw_core_new(pw_loop_, /*properties=*/nullptr);
+   pw_core_type_ = pw_core_get_type(pw_core_);
+   pw_remote_ = pw_remote_new(pw_core_, nullptr, /*user_data_size=*/0);
+ 
+   InitPipeWireTypes();
++#endif
+ 
+   // Initialize event handlers, remote end and stream-related.
++#if PW_CHECK_VERSION(0, 3, 0)
++  pw_core_events_.version = PW_VERSION_CORE_EVENTS;
++  pw_core_events_.error = &OnCoreError;
++
++  pw_stream_events_.version = PW_VERSION_STREAM_EVENTS;
++  pw_stream_events_.state_changed = &OnStreamStateChanged;
++  pw_stream_events_.param_changed = &OnStreamParamChanged;
++  pw_stream_events_.process = &OnStreamProcess;
++#else
+   pw_remote_events_.version = PW_VERSION_REMOTE_EVENTS;
+   pw_remote_events_.state_changed = &OnStateChanged;
+ 
+@@ -301,19 +574,33 @@ void BaseCapturerPipeWire::InitPipeWire() {
+   pw_stream_events_.state_changed = &OnStreamStateChanged;
+   pw_stream_events_.format_changed = &OnStreamFormatChanged;
+   pw_stream_events_.process = &OnStreamProcess;
++#endif
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  pw_core_add_listener(pw_core_, &spa_core_listener_, &pw_core_events_, this);
++
++  pw_stream_ = CreateReceivingStream();
++  if (!pw_stream_) {
++    RTC_LOG(LS_ERROR) << "Failed to create PipeWire stream";
++    return;
++  }
++#else
+   pw_remote_add_listener(pw_remote_, &spa_remote_listener_, &pw_remote_events_,
+                          this);
+   pw_remote_connect_fd(pw_remote_, pw_fd_);
++#endif
+ 
+   if (pw_thread_loop_start(pw_main_loop_) < 0) {
+     RTC_LOG(LS_ERROR) << "Failed to start main PipeWire loop";
+     portal_init_failed_ = true;
+   }
+ 
++  pw_thread_loop_unlock(pw_main_loop_);
++
+   RTC_LOG(LS_INFO) << "PipeWire remote opened.";
+ }
+ 
++#if !PW_CHECK_VERSION(0, 3, 0)
+ void BaseCapturerPipeWire::InitPipeWireTypes() {
+   spa_type_map* map = pw_core_type_->map;
+   pw_type_ = new PipeWireType();
+@@ -323,23 +610,44 @@ void BaseCapturerPipeWire::InitPipeWireTypes() {
+   spa_type_format_video_map(map, &pw_type_->format_video);
+   spa_type_video_format_map(map, &pw_type_->video_format);
+ }
++#endif
+ 
+-void BaseCapturerPipeWire::CreateReceivingStream() {
++pw_stream* BaseCapturerPipeWire::CreateReceivingStream() {
++#if !PW_CHECK_VERSION(0, 3, 0)
++  if (pw_remote_get_state(pw_remote_, nullptr) != PW_REMOTE_STATE_CONNECTED) {
++    RTC_LOG(LS_ERROR) << "Cannot create pipewire stream";
++    return nullptr;
++  }
++#endif
+   spa_rectangle pwMinScreenBounds = spa_rectangle{1, 1};
+-  spa_rectangle pwScreenBounds =
+-      spa_rectangle{static_cast<uint32_t>(desktop_size_.width()),
+-                    static_cast<uint32_t>(desktop_size_.height())};
+-
+-  spa_fraction pwFrameRateMin = spa_fraction{0, 1};
+-  spa_fraction pwFrameRateMax = spa_fraction{60, 1};
++  spa_rectangle pwMaxScreenBounds = spa_rectangle{UINT32_MAX, UINT32_MAX};
+ 
+   pw_properties* reuseProps =
+       pw_properties_new_string("pipewire.client.reuse=1");
+-  pw_stream_ = pw_stream_new(pw_remote_, "webrtc-consume-stream", reuseProps);
++#if PW_CHECK_VERSION(0, 3, 0)
++  auto stream = pw_stream_new(pw_core_, "webrtc-consume-stream", reuseProps);
++#else
++  auto stream = pw_stream_new(pw_remote_, "webrtc-consume-stream", reuseProps);
++#endif
+ 
+   uint8_t buffer[1024] = {};
+   const spa_pod* params[1];
+   spa_pod_builder builder = spa_pod_builder{buffer, sizeof(buffer)};
++
++#if PW_CHECK_VERSION(0, 3, 0)
++  params[0] = reinterpret_cast<spa_pod*>(spa_pod_builder_add_object(
++      &builder, SPA_TYPE_OBJECT_Format, SPA_PARAM_EnumFormat,
++      SPA_FORMAT_mediaType, SPA_POD_Id(SPA_MEDIA_TYPE_video),
++      SPA_FORMAT_mediaSubtype, SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
++      SPA_FORMAT_VIDEO_format,
++      SPA_POD_CHOICE_ENUM_Id(5, SPA_VIDEO_FORMAT_BGRx, SPA_VIDEO_FORMAT_RGBx,
++                             SPA_VIDEO_FORMAT_RGBA, SPA_VIDEO_FORMAT_BGRx,
++                             SPA_VIDEO_FORMAT_BGRA),
++      SPA_FORMAT_VIDEO_size,
++      SPA_POD_CHOICE_RANGE_Rectangle(&pwMinScreenBounds, &pwMinScreenBounds,
++                                     &pwMaxScreenBounds),
++      0));
++#else
+   params[0] = reinterpret_cast<spa_pod*>(spa_pod_builder_object(
+       &builder,
+       // id to enumerate formats
+@@ -349,69 +657,218 @@ void BaseCapturerPipeWire::CreateReceivingStream() {
+       // then allowed formats are enumerated (e) and the format is undecided (u)
+       // to allow negotiation
+       ":", pw_type_->format_video.format, "Ieu", pw_type_->video_format.BGRx,
+-      SPA_POD_PROP_ENUM(2, pw_type_->video_format.RGBx,
+-                        pw_type_->video_format.BGRx),
++      SPA_POD_PROP_ENUM(
++          4, pw_type_->video_format.RGBx, pw_type_->video_format.BGRx,
++          pw_type_->video_format.RGBA, pw_type_->video_format.BGRA),
+       // Video size: specified as rectangle (R), preferred size is specified as
+       // first parameter, then allowed size is defined as range (r) from min and
+       // max values and the format is undecided (u) to allow negotiation
+-      ":", pw_type_->format_video.size, "Rru", &pwScreenBounds, 2,
+-      &pwMinScreenBounds, &pwScreenBounds,
+-      // Frame rate: specified as fraction (F) and set to minimum frame rate
+-      // value
+-      ":", pw_type_->format_video.framerate, "F", &pwFrameRateMin,
+-      // Max frame rate: specified as fraction (F), preferred frame rate is set
+-      // to maximum value, then allowed frame rate is defined as range (r) from
+-      // min and max values and it is undecided (u) to allow negotiation
+-      ":", pw_type_->format_video.max_framerate, "Fru", &pwFrameRateMax, 2,
+-      &pwFrameRateMin, &pwFrameRateMax));
+-
+-  pw_stream_add_listener(pw_stream_, &spa_stream_listener_, &pw_stream_events_,
++      ":", pw_type_->format_video.size, "Rru", &pwMinScreenBounds,
++      SPA_POD_PROP_MIN_MAX(&pwMinScreenBounds, &pwMaxScreenBounds)));
++#endif
++
++  pw_stream_add_listener(stream, &spa_stream_listener_, &pw_stream_events_,
+                          this);
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (pw_stream_connect(stream, PW_DIRECTION_INPUT, pw_stream_node_id_,
++                        PW_STREAM_FLAG_AUTOCONNECT, params, 1) != 0) {
++#else
+   pw_stream_flags flags = static_cast<pw_stream_flags>(
+-      PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE |
+-      PW_STREAM_FLAG_MAP_BUFFERS);
+-  if (pw_stream_connect(pw_stream_, PW_DIRECTION_INPUT, /*port_path=*/nullptr,
++      PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE);
++  if (pw_stream_connect(stream, PW_DIRECTION_INPUT, /*port_path=*/nullptr,
+                         flags, params,
+                         /*n_params=*/1) != 0) {
++#endif
+     RTC_LOG(LS_ERROR) << "Could not connect receiving stream.";
+     portal_init_failed_ = true;
+-    return;
++    return nullptr;
+   }
++
++  return stream;
+ }
+ 
+ void BaseCapturerPipeWire::HandleBuffer(pw_buffer* buffer) {
+   spa_buffer* spaBuffer = buffer->buffer;
+-  void* src = nullptr;
++  ScopedBuf map;
++  uint8_t* src = nullptr;
++
++  if (spaBuffer->datas[0].chunk->size == 0) {
++    RTC_LOG(LS_ERROR) << "Failed to get video stream: Zero size.";
++    return;
++  }
++
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (spaBuffer->datas[0].type == SPA_DATA_MemFd ||
++      spaBuffer->datas[0].type == SPA_DATA_DmaBuf) {
++#else
++  if (spaBuffer->datas[0].type == pw_core_type_->data.MemFd ||
++      spaBuffer->datas[0].type == pw_core_type_->data.DmaBuf) {
++#endif
++    map.initialize(
++        static_cast<uint8_t*>(
++            mmap(nullptr,
++                 spaBuffer->datas[0].maxsize + spaBuffer->datas[0].mapoffset,
++                 PROT_READ, MAP_PRIVATE, spaBuffer->datas[0].fd, 0)),
++        spaBuffer->datas[0].maxsize + spaBuffer->datas[0].mapoffset,
++#if PW_CHECK_VERSION(0, 3, 0)
++        spaBuffer->datas[0].type == SPA_DATA_DmaBuf,
++#else
++        spaBuffer->datas[0].type == pw_core_type_->data.DmaBuf,
++#endif
++        spaBuffer->datas[0].fd);
++
++    if (!map) {
++      RTC_LOG(LS_ERROR) << "Failed to mmap the memory: "
++                        << std::strerror(errno);
++      return;
++    }
++
++#if PW_CHECK_VERSION(0, 3, 0)
++    if (spaBuffer->datas[0].type == SPA_DATA_DmaBuf) {
++#else
++    if (spaBuffer->datas[0].type == pw_core_type_->data.DmaBuf) {
++#endif
++      SyncDmaBuf(spaBuffer->datas[0].fd, DMA_BUF_SYNC_START);
++    }
++
++    src = SPA_MEMBER(map.get(), spaBuffer->datas[0].mapoffset, uint8_t);
++#if PW_CHECK_VERSION(0, 3, 0)
++  } else if (spaBuffer->datas[0].type == SPA_DATA_MemPtr) {
++#else
++  } else if (spaBuffer->datas[0].type == pw_core_type_->data.MemPtr) {
++#endif
++    src = static_cast<uint8_t*>(spaBuffer->datas[0].data);
++  }
+ 
+-  if (!(src = spaBuffer->datas[0].data)) {
++  if (!src) {
++    return;
++  }
++
++#if PW_CHECK_VERSION(0, 3, 0)
++  struct spa_meta_region* video_metadata =
++      static_cast<struct spa_meta_region*>(spa_buffer_find_meta_data(
++          spaBuffer, SPA_META_VideoCrop, sizeof(*video_metadata)));
++#else
++  struct spa_meta_video_crop* video_metadata =
++      static_cast<struct spa_meta_video_crop*>(
++          spa_buffer_find_meta(spaBuffer, pw_core_type_->meta.VideoCrop));
++#endif
++
++  // Video size from metadata is bigger than an actual video stream size.
++  // The metadata are wrong or we should up-scale the video...in both cases
++  // just quit now.
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (video_metadata && (video_metadata->region.size.width >
++                             static_cast<uint32_t>(desktop_size_.width()) ||
++                         video_metadata->region.size.height >
++                             static_cast<uint32_t>(desktop_size_.height()))) {
++#else
++  if (video_metadata && (video_metadata->width > desktop_size_.width() ||
++                         video_metadata->height > desktop_size_.height())) {
++#endif
++    RTC_LOG(LS_ERROR) << "Stream metadata sizes are wrong!";
+     return;
+   }
+ 
+-  uint32_t maxSize = spaBuffer->datas[0].maxsize;
+-  int32_t srcStride = spaBuffer->datas[0].chunk->stride;
+-  if (srcStride != (desktop_size_.width() * kBytesPerPixel)) {
++  // Use video metadata when video size from metadata is set and smaller than
++  // video stream size, so we need to adjust it.
++  bool video_is_full_width = true;
++  bool video_is_full_height = true;
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (video_metadata && video_metadata->region.size.width != 0 &&
++      video_metadata->region.size.height != 0) {
++    if (video_metadata->region.size.width <
++        static_cast<uint32_t>(desktop_size_.width())) {
++      video_is_full_width = false;
++    } else if (video_metadata->region.size.height <
++               static_cast<uint32_t>(desktop_size_.height())) {
++      video_is_full_height = false;
++    }
++  }
++#else
++  if (video_metadata && video_metadata->width != 0 &&
++      video_metadata->height != 0) {
++    if (video_metadata->width < desktop_size_.width()) {
++    } else if (video_metadata->height < desktop_size_.height()) {
++      video_is_full_height = false;
++    }
++  }
++#endif
++
++  DesktopSize video_size_prev = video_size_;
++  if (!video_is_full_height || !video_is_full_width) {
++#if PW_CHECK_VERSION(0, 3, 0)
++    video_size_ = DesktopSize(video_metadata->region.size.width,
++                              video_metadata->region.size.height);
++#else
++    video_size_ = DesktopSize(video_metadata->width, video_metadata->height);
++#endif
++  } else {
++    video_size_ = desktop_size_;
++  }
++
++  webrtc::MutexLock lock(&current_frame_lock_);
++  if (!current_frame_ || !video_size_.equals(video_size_prev)) {
++    current_frame_ = std::make_unique<uint8_t[]>(
++        video_size_.width() * video_size_.height() * kBytesPerPixel);
++  }
++
++  const int32_t dst_stride = video_size_.width() * kBytesPerPixel;
++  const int32_t src_stride = spaBuffer->datas[0].chunk->stride;
++
++  if (src_stride != (desktop_size_.width() * kBytesPerPixel)) {
+     RTC_LOG(LS_ERROR) << "Got buffer with stride different from screen stride: "
+-                      << srcStride
++                      << src_stride
+                       << " != " << (desktop_size_.width() * kBytesPerPixel);
+     portal_init_failed_ = true;
++
+     return;
+   }
+ 
+-  if (!current_frame_) {
+-    current_frame_ = static_cast<uint8_t*>(malloc(maxSize));
+-  }
+-  RTC_DCHECK(current_frame_ != nullptr);
+-
+-  // If both sides decided to go with the RGBx format we need to convert it to
+-  // BGRx to match color format expected by WebRTC.
+-  if (spa_video_format_->format == pw_type_->video_format.RGBx) {
+-    uint8_t* tempFrame = static_cast<uint8_t*>(malloc(maxSize));
+-    std::memcpy(tempFrame, src, maxSize);
+-    ConvertRGBxToBGRx(tempFrame, maxSize);
+-    std::memcpy(current_frame_, tempFrame, maxSize);
+-    free(tempFrame);
+-  } else {
+-    std::memcpy(current_frame_, src, maxSize);
++  // Adjust source content based on metadata video position
++#if PW_CHECK_VERSION(0, 3, 0)
++  if (!video_is_full_height &&
++      (video_metadata->region.position.y + video_size_.height() <=
++       desktop_size_.height())) {
++    src += src_stride * video_metadata->region.position.y;
++  }
++  const int x_offset =
++      !video_is_full_width &&
++              (video_metadata->region.position.x + video_size_.width() <=
++               desktop_size_.width())
++          ? video_metadata->region.position.x * kBytesPerPixel
++          : 0;
++#else
++  if (!video_is_full_height &&
++      (video_metadata->y + video_size_.height() <= desktop_size_.height())) {
++    src += src_stride * video_metadata->y;
++  }
++
++  const int x_offset =
++      !video_is_full_width &&
++              (video_metadata->x + video_size_.width() <= desktop_size_.width())
++          ? video_metadata->x * kBytesPerPixel
++          : 0;
++#endif
++
++  uint8_t* dst = current_frame_.get();
++  for (int i = 0; i < video_size_.height(); ++i) {
++    // Adjust source content based on crop video position if needed
++    src += x_offset;
++    std::memcpy(dst, src, dst_stride);
++    // If both sides decided to go with the RGBx format we need to convert it to
++    // BGRx to match color format expected by WebRTC.
++#if PW_CHECK_VERSION(0, 3, 0)
++    if (spa_video_format_.format == SPA_VIDEO_FORMAT_RGBx ||
++        spa_video_format_.format == SPA_VIDEO_FORMAT_RGBA) {
++#else
++    if (spa_video_format_->format == pw_type_->video_format.RGBx ||
++        spa_video_format_->format == pw_type_->video_format.RGBA) {
++#endif
++      ConvertRGBxToBGRx(dst, dst_stride);
++    }
++    src += src_stride - x_offset;
++    dst += dst_stride;
+   }
+ }
+ 
+@@ -441,14 +898,13 @@ void BaseCapturerPipeWire::OnProxyRequested(GObject* /*object*/,
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(user_data);
+   RTC_DCHECK(that);
+ 
+-  GError* error = nullptr;
+-  GDBusProxy *proxy = g_dbus_proxy_new_finish(result, &error);
++  Scoped<GError> error;
++  GDBusProxy* proxy = g_dbus_proxy_new_finish(result, error.receive());
+   if (!proxy) {
+-    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+       return;
+     RTC_LOG(LS_ERROR) << "Failed to create a proxy for the screen cast portal: "
+                       << error->message;
+-    g_error_free(error);
+     that->portal_init_failed_ = true;
+     return;
+   }
+@@ -462,38 +918,36 @@ void BaseCapturerPipeWire::OnProxyRequested(GObject* /*object*/,
+ // static
+ gchar* BaseCapturerPipeWire::PrepareSignalHandle(GDBusConnection* connection,
+                                                  const gchar* token) {
+-  gchar* sender = g_strdup(g_dbus_connection_get_unique_name(connection) + 1);
+-  for (int i = 0; sender[i]; i++) {
+-    if (sender[i] == '.') {
+-      sender[i] = '_';
++  Scoped<gchar> sender(
++      g_strdup(g_dbus_connection_get_unique_name(connection) + 1));
++  for (int i = 0; sender.get()[i]; i++) {
++    if (sender.get()[i] == '.') {
++      sender.get()[i] = '_';
+     }
+   }
+ 
+-  gchar* handle = g_strconcat(kDesktopRequestObjectPath, "/", sender, "/",
++  gchar* handle = g_strconcat(kDesktopRequestObjectPath, "/", sender.get(), "/",
+                               token, /*end of varargs*/ nullptr);
+-  g_free(sender);
+ 
+   return handle;
+ }
+ 
+ void BaseCapturerPipeWire::SessionRequest() {
+   GVariantBuilder builder;
+-  gchar* variant_string;
++  Scoped<gchar> variant_string;
+ 
+   g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+   variant_string =
+       g_strdup_printf("webrtc_session%d", g_random_int_range(0, G_MAXINT));
+   g_variant_builder_add(&builder, "{sv}", "session_handle_token",
+-                        g_variant_new_string(variant_string));
+-  g_free(variant_string);
++                        g_variant_new_string(variant_string.get()));
+   variant_string = g_strdup_printf("webrtc%d", g_random_int_range(0, G_MAXINT));
+   g_variant_builder_add(&builder, "{sv}", "handle_token",
+-                        g_variant_new_string(variant_string));
++                        g_variant_new_string(variant_string.get()));
+ 
+-  portal_handle_ = PrepareSignalHandle(connection_, variant_string);
++  portal_handle_ = PrepareSignalHandle(connection_, variant_string.get());
+   session_request_signal_id_ = SetupRequestResponseSignal(
+       portal_handle_, OnSessionRequestResponseSignal);
+-  g_free(variant_string);
+ 
+   RTC_LOG(LS_INFO) << "Screen cast session requested.";
+   g_dbus_proxy_call(
+@@ -509,22 +963,21 @@ void BaseCapturerPipeWire::OnSessionRequested(GDBusProxy *proxy,
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(user_data);
+   RTC_DCHECK(that);
+ 
+-  GError* error = nullptr;
+-  GVariant* variant = g_dbus_proxy_call_finish(proxy, result, &error);
++  Scoped<GError> error;
++  Scoped<GVariant> variant(
++      g_dbus_proxy_call_finish(proxy, result, error.receive()));
+   if (!variant) {
+-    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+       return;
+     RTC_LOG(LS_ERROR) << "Failed to create a screen cast session: "
+                       << error->message;
+-    g_error_free(error);
+     that->portal_init_failed_ = true;
+     return;
+   }
+   RTC_LOG(LS_INFO) << "Initializing the screen cast session.";
+ 
+-  gchar* handle = nullptr;
+-  g_variant_get_child(variant, 0, "o", &handle);
+-  g_variant_unref(variant);
++  Scoped<gchar> handle;
++  g_variant_get_child(variant.get(), 0, "o", &handle);
+   if (!handle) {
+     RTC_LOG(LS_ERROR) << "Failed to initialize the screen cast session.";
+     if (that->session_request_signal_id_) {
+@@ -536,8 +989,6 @@ void BaseCapturerPipeWire::OnSessionRequested(GDBusProxy *proxy,
+     return;
+   }
+ 
+-  g_free(handle);
+-
+   RTC_LOG(LS_INFO) << "Subscribing to the screen cast session.";
+ }
+ 
+@@ -557,11 +1008,11 @@ void BaseCapturerPipeWire::OnSessionRequestResponseSignal(
+       << "Received response for the screen cast session subscription.";
+ 
+   guint32 portal_response;
+-  GVariant* response_data;
+-  g_variant_get(parameters, "(u@a{sv})", &portal_response, &response_data);
+-  g_variant_lookup(response_data, "session_handle", "s",
++  Scoped<GVariant> response_data;
++  g_variant_get(parameters, "(u@a{sv})", &portal_response,
++                response_data.receive());
++  g_variant_lookup(response_data.get(), "session_handle", "s",
+                    &that->session_handle_);
+-  g_variant_unref(response_data);
+ 
+   if (!that->session_handle_ || portal_response) {
+     RTC_LOG(LS_ERROR)
+@@ -575,23 +1026,23 @@ void BaseCapturerPipeWire::OnSessionRequestResponseSignal(
+ 
+ void BaseCapturerPipeWire::SourcesRequest() {
+   GVariantBuilder builder;
+-  gchar* variant_string;
++  Scoped<gchar> variant_string;
+ 
+   g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+   // We want to record monitor content.
+-  g_variant_builder_add(&builder, "{sv}", "types",
+-                        g_variant_new_uint32(capture_source_type_));
++  g_variant_builder_add(
++      &builder, "{sv}", "types",
++      g_variant_new_uint32(static_cast<uint32_t>(capture_source_type_)));
+   // We don't want to allow selection of multiple sources.
+   g_variant_builder_add(&builder, "{sv}", "multiple",
+                         g_variant_new_boolean(false));
+   variant_string = g_strdup_printf("webrtc%d", g_random_int_range(0, G_MAXINT));
+   g_variant_builder_add(&builder, "{sv}", "handle_token",
+-                        g_variant_new_string(variant_string));
++                        g_variant_new_string(variant_string.get()));
+ 
+-  sources_handle_ = PrepareSignalHandle(connection_, variant_string);
++  sources_handle_ = PrepareSignalHandle(connection_, variant_string.get());
+   sources_request_signal_id_ = SetupRequestResponseSignal(
+       sources_handle_, OnSourcesRequestResponseSignal);
+-  g_free(variant_string);
+ 
+   RTC_LOG(LS_INFO) << "Requesting sources from the screen cast session.";
+   g_dbus_proxy_call(
+@@ -608,22 +1059,21 @@ void BaseCapturerPipeWire::OnSourcesRequested(GDBusProxy *proxy,
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(user_data);
+   RTC_DCHECK(that);
+ 
+-  GError* error = nullptr;
+-  GVariant* variant = g_dbus_proxy_call_finish(proxy, result, &error);
++  Scoped<GError> error;
++  Scoped<GVariant> variant(
++      g_dbus_proxy_call_finish(proxy, result, error.receive()));
+   if (!variant) {
+-    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+       return;
+     RTC_LOG(LS_ERROR) << "Failed to request the sources: " << error->message;
+-    g_error_free(error);
+     that->portal_init_failed_ = true;
+     return;
+   }
+ 
+   RTC_LOG(LS_INFO) << "Sources requested from the screen cast session.";
+ 
+-  gchar* handle = nullptr;
+-  g_variant_get_child(variant, 0, "o", &handle);
+-  g_variant_unref(variant);
++  Scoped<gchar> handle;
++  g_variant_get_child(variant.get(), 0, "o", handle.receive());
+   if (!handle) {
+     RTC_LOG(LS_ERROR) << "Failed to initialize the screen cast session.";
+     if (that->sources_request_signal_id_) {
+@@ -635,8 +1085,6 @@ void BaseCapturerPipeWire::OnSourcesRequested(GDBusProxy *proxy,
+     return;
+   }
+ 
+-  g_free(handle);
+-
+   RTC_LOG(LS_INFO) << "Subscribed to sources signal.";
+ }
+ 
+@@ -668,17 +1116,16 @@ void BaseCapturerPipeWire::OnSourcesRequestResponseSignal(
+ 
+ void BaseCapturerPipeWire::StartRequest() {
+   GVariantBuilder builder;
+-  gchar* variant_string;
++  Scoped<gchar> variant_string;
+ 
+   g_variant_builder_init(&builder, G_VARIANT_TYPE_VARDICT);
+   variant_string = g_strdup_printf("webrtc%d", g_random_int_range(0, G_MAXINT));
+   g_variant_builder_add(&builder, "{sv}", "handle_token",
+-                        g_variant_new_string(variant_string));
++                        g_variant_new_string(variant_string.get()));
+ 
+-  start_handle_ = PrepareSignalHandle(connection_, variant_string);
++  start_handle_ = PrepareSignalHandle(connection_, variant_string.get());
+   start_request_signal_id_ =
+       SetupRequestResponseSignal(start_handle_, OnStartRequestResponseSignal);
+-  g_free(variant_string);
+ 
+   // "Identifier for the application window", this is Wayland, so not "x11:...".
+   const gchar parent_window[] = "";
+@@ -698,23 +1145,22 @@ void BaseCapturerPipeWire::OnStartRequested(GDBusProxy *proxy,
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(user_data);
+   RTC_DCHECK(that);
+ 
+-  GError* error = nullptr;
+-  GVariant* variant = g_dbus_proxy_call_finish(proxy, result, &error);
++  Scoped<GError> error;
++  Scoped<GVariant> variant(
++      g_dbus_proxy_call_finish(proxy, result, error.receive()));
+   if (!variant) {
+-    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+       return;
+     RTC_LOG(LS_ERROR) << "Failed to start the screen cast session: "
+                       << error->message;
+-    g_error_free(error);
+     that->portal_init_failed_ = true;
+     return;
+   }
+ 
+   RTC_LOG(LS_INFO) << "Initializing the start of the screen cast session.";
+ 
+-  gchar* handle = nullptr;
+-  g_variant_get_child(variant, 0, "o", &handle);
+-  g_variant_unref(variant);
++  Scoped<gchar> handle;
++  g_variant_get_child(variant.get(), 0, "o", handle.receive());
+   if (!handle) {
+     RTC_LOG(LS_ERROR)
+         << "Failed to initialize the start of the screen cast session.";
+@@ -727,8 +1173,6 @@ void BaseCapturerPipeWire::OnStartRequested(GDBusProxy *proxy,
+     return;
+   }
+ 
+-  g_free(handle);
+-
+   RTC_LOG(LS_INFO) << "Subscribed to the start signal.";
+ }
+ 
+@@ -746,9 +1190,10 @@ void BaseCapturerPipeWire::OnStartRequestResponseSignal(
+ 
+   RTC_LOG(LS_INFO) << "Start signal received.";
+   guint32 portal_response;
+-  GVariant* response_data;
+-  GVariantIter* iter = nullptr;
+-  g_variant_get(parameters, "(u@a{sv})", &portal_response, &response_data);
++  Scoped<GVariant> response_data;
++  Scoped<GVariantIter> iter;
++  g_variant_get(parameters, "(u@a{sv})", &portal_response,
++                response_data.receive());
+   if (portal_response || !response_data) {
+     RTC_LOG(LS_ERROR) << "Failed to start the screen cast session.";
+     that->portal_init_failed_ = true;
+@@ -758,28 +1203,28 @@ void BaseCapturerPipeWire::OnStartRequestResponseSignal(
+   // Array of PipeWire streams. See
+   // https://github.com/flatpak/xdg-desktop-portal/blob/master/data/org.freedesktop.portal.ScreenCast.xml
+   // documentation for <method name="Start">.
+-  if (g_variant_lookup(response_data, "streams", "a(ua{sv})", &iter)) {
+-    GVariant* variant;
++  if (g_variant_lookup(response_data.get(), "streams", "a(ua{sv})",
++                       iter.receive())) {
++    Scoped<GVariant> variant;
+ 
+-    while (g_variant_iter_next(iter, "@(ua{sv})", &variant)) {
++    while (g_variant_iter_next(iter.get(), "@(ua{sv})", variant.receive())) {
+       guint32 stream_id;
+-      gint32 width;
+-      gint32 height;
+-      GVariant* options;
++      guint32 type;
++      Scoped<GVariant> options;
+ 
+-      g_variant_get(variant, "(u@a{sv})", &stream_id, &options);
+-      RTC_DCHECK(options != nullptr);
++      g_variant_get(variant.get(), "(u@a{sv})", &stream_id, options.receive());
++      RTC_DCHECK(options.get());
+ 
+-      g_variant_lookup(options, "size", "(ii)", &width, &height);
++      if (g_variant_lookup(options.get(), "source_type", "u", &type)) {
++        that->capture_source_type_ =
++            static_cast<BaseCapturerPipeWire::CaptureSourceType>(type);
++      }
+ 
+-      that->desktop_size_.set(width, height);
++      that->pw_stream_node_id_ = stream_id;
+ 
+-      g_variant_unref(options);
+-      g_variant_unref(variant);
++      break;
+     }
+   }
+-  g_variant_iter_free(iter);
+-  g_variant_unref(response_data);
+ 
+   that->OpenPipeWireRemote();
+ }
+@@ -807,35 +1252,30 @@ void BaseCapturerPipeWire::OnOpenPipeWireRemoteRequested(
+   BaseCapturerPipeWire* that = static_cast<BaseCapturerPipeWire*>(user_data);
+   RTC_DCHECK(that);
+ 
+-  GError* error = nullptr;
+-  GUnixFDList* outlist = nullptr;
+-  GVariant* variant = g_dbus_proxy_call_with_unix_fd_list_finish(
+-      proxy, &outlist, result, &error);
++  Scoped<GError> error;
++  Scoped<GUnixFDList> outlist;
++  Scoped<GVariant> variant(g_dbus_proxy_call_with_unix_fd_list_finish(
++      proxy, outlist.receive(), result, error.receive()));
+   if (!variant) {
+-    if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++    if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_CANCELLED))
+       return;
+     RTC_LOG(LS_ERROR) << "Failed to open the PipeWire remote: "
+                       << error->message;
+-    g_error_free(error);
+     that->portal_init_failed_ = true;
+     return;
+   }
+ 
+   gint32 index;
+-  g_variant_get(variant, "(h)", &index);
++  g_variant_get(variant.get(), "(h)", &index);
+ 
+-  if ((that->pw_fd_ = g_unix_fd_list_get(outlist, index, &error)) == -1) {
++  if ((that->pw_fd_ =
++           g_unix_fd_list_get(outlist.get(), index, error.receive())) == -1) {
+     RTC_LOG(LS_ERROR) << "Failed to get file descriptor from the list: "
+                       << error->message;
+-    g_error_free(error);
+-    g_variant_unref(variant);
+     that->portal_init_failed_ = true;
+     return;
+   }
+ 
+-  g_variant_unref(variant);
+-  g_object_unref(outlist);
+-
+   that->InitPipeWire();
+ }
+ 
+@@ -854,15 +1294,18 @@ void BaseCapturerPipeWire::CaptureFrame() {
+     return;
+   }
+ 
++  webrtc::MutexLock lock(&current_frame_lock_);
+   if (!current_frame_) {
+     callback_->OnCaptureResult(Result::ERROR_TEMPORARY, nullptr);
+     return;
+   }
+ 
+-  std::unique_ptr<DesktopFrame> result(new BasicDesktopFrame(desktop_size_));
++  DesktopSize frame_size = video_size_;
++
++  std::unique_ptr<DesktopFrame> result(new BasicDesktopFrame(frame_size));
+   result->CopyPixelsFrom(
+-      current_frame_, (desktop_size_.width() * kBytesPerPixel),
+-      DesktopRect::MakeWH(desktop_size_.width(), desktop_size_.height()));
++      current_frame_.get(), (frame_size.width() * kBytesPerPixel),
++      DesktopRect::MakeWH(frame_size.width(), frame_size.height()));
+   if (!result) {
+     callback_->OnCaptureResult(Result::ERROR_TEMPORARY, nullptr);
+     return;
+@@ -887,4 +1330,11 @@ bool BaseCapturerPipeWire::SelectSource(SourceId id) {
+   return true;
+ }
+ 
++// static
++std::unique_ptr<DesktopCapturer> BaseCapturerPipeWire::CreateRawCapturer(
++    const DesktopCaptureOptions& options) {
++  return std::make_unique<BaseCapturerPipeWire>(
++      BaseCapturerPipeWire::CaptureSourceType::kAny);
++}
++
+ }  // namespace webrtc
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.h b/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.h
+index f28d7a558bc..75d20dbf1db 100644
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.h
++++ b/chromium/third_party/webrtc/modules/desktop_capture/linux/base_capturer_pipewire.h
+@@ -10,18 +10,23 @@
+ 
+ #ifndef MODULES_DESKTOP_CAPTURE_LINUX_BASE_CAPTURER_PIPEWIRE_H_
+ #define MODULES_DESKTOP_CAPTURE_LINUX_BASE_CAPTURER_PIPEWIRE_H_
+-
+ #include <gio/gio.h>
+ #define typeof __typeof__
+ #include <pipewire/pipewire.h>
+ #include <spa/param/video/format-utils.h>
++#if PW_CHECK_VERSION(0, 3, 0)
++#include <spa/utils/result.h>
++#endif
+ 
++#include "absl/types/optional.h"
+ #include "modules/desktop_capture/desktop_capture_options.h"
+ #include "modules/desktop_capture/desktop_capturer.h"
+ #include "rtc_base/constructor_magic.h"
++#include "rtc_base/synchronization/mutex.h"
+ 
+ namespace webrtc {
+ 
++#if !PW_CHECK_VERSION(0, 3, 0)
+ class PipeWireType {
+  public:
+   spa_type_media_type media_type;
+@@ -29,14 +34,25 @@ class PipeWireType {
+   spa_type_format_video format_video;
+   spa_type_video_format video_format;
+ };
++#endif
+ 
+ class BaseCapturerPipeWire : public DesktopCapturer {
+  public:
+-  enum CaptureSourceType { Screen = 1, Window };
++  // Values are set based on source type property in
++  // xdg-desktop-portal/screencast
++  // https://github.com/flatpak/xdg-desktop-portal/blob/master/data/org.freedesktop.portal.ScreenCast.xml
++  enum class CaptureSourceType : uint32_t {
++    kScreen = 0b01,
++    kWindow = 0b10,
++    kAny = 0b11
++  };
+ 
+   explicit BaseCapturerPipeWire(CaptureSourceType source_type);
+   ~BaseCapturerPipeWire() override;
+ 
++  static std::unique_ptr<DesktopCapturer> CreateRawCapturer(
++      const DesktopCaptureOptions& options);
++
+   // DesktopCapturer interface.
+   void Start(Callback* delegate) override;
+   void CaptureFrame() override;
+@@ -45,6 +61,21 @@ class BaseCapturerPipeWire : public DesktopCapturer {
+ 
+  private:
+   // PipeWire types -->
++#if PW_CHECK_VERSION(0, 3, 0)
++  struct pw_context* pw_context_ = nullptr;
++  struct pw_core* pw_core_ = nullptr;
++  struct pw_stream* pw_stream_ = nullptr;
++  struct pw_thread_loop* pw_main_loop_ = nullptr;
++
++  spa_hook spa_core_listener_;
++  spa_hook spa_stream_listener_;
++
++  // event handlers
++  pw_core_events pw_core_events_ = {};
++  pw_stream_events pw_stream_events_ = {};
++
++  struct spa_video_info_raw spa_video_format_;
++#else
+   pw_core* pw_core_ = nullptr;
+   pw_type* pw_core_type_ = nullptr;
+   pw_stream* pw_stream_ = nullptr;
+@@ -60,11 +91,13 @@ class BaseCapturerPipeWire : public DesktopCapturer {
+   pw_remote_events pw_remote_events_ = {};
+ 
+   spa_video_info_raw* spa_video_format_ = nullptr;
++#endif
+ 
++  guint32 pw_stream_node_id_ = 0;
+   gint32 pw_fd_ = -1;
+ 
+   CaptureSourceType capture_source_type_ =
+-      BaseCapturerPipeWire::CaptureSourceType::Screen;
++      BaseCapturerPipeWire::CaptureSourceType::kScreen;
+ 
+   // <-- end of PipeWire types
+ 
+@@ -79,10 +112,12 @@ class BaseCapturerPipeWire : public DesktopCapturer {
+   guint sources_request_signal_id_ = 0;
+   guint start_request_signal_id_ = 0;
+ 
++  DesktopSize video_size_;
+   DesktopSize desktop_size_ = {};
+   DesktopCaptureOptions options_ = {};
+ 
+-  uint8_t* current_frame_ = nullptr;
++  webrtc::Mutex current_frame_lock_;
++  std::unique_ptr<uint8_t[]> current_frame_;
+   Callback* callback_ = nullptr;
+ 
+   bool portal_init_failed_ = false;
+@@ -91,21 +126,32 @@ class BaseCapturerPipeWire : public DesktopCapturer {
+   void InitPipeWire();
+   void InitPipeWireTypes();
+ 
+-  void CreateReceivingStream();
++  pw_stream* CreateReceivingStream();
+   void HandleBuffer(pw_buffer* buffer);
+ 
+   void ConvertRGBxToBGRx(uint8_t* frame, uint32_t size);
+ 
++#if PW_CHECK_VERSION(0, 3, 0)
++  static void OnCoreError(void* data,
++                          uint32_t id,
++                          int seq,
++                          int res,
++                          const char* message);
++  static void OnStreamParamChanged(void* data,
++                                   uint32_t id,
++                                   const struct spa_pod* format);
++#else
+   static void OnStateChanged(void* data,
+                              pw_remote_state old_state,
+                              pw_remote_state state,
+                              const char* error);
++  static void OnStreamFormatChanged(void* data, const struct spa_pod* format);
++#endif
+   static void OnStreamStateChanged(void* data,
+                                    pw_stream_state old_state,
+                                    pw_stream_state state,
+                                    const char* error_message);
+ 
+-  static void OnStreamFormatChanged(void* data, const struct spa_pod* format);
+   static void OnStreamProcess(void* data);
+   static void OnNewBuffer(void* data, uint32_t id);
+ 
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire.sigs b/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire.sigs
+deleted file mode 100644
+index 3e21e9dc07c..00000000000
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire.sigs
++++ /dev/null
+@@ -1,44 +0,0 @@
+-// Copyright 2018 The WebRTC project authors. All rights reserved.
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-//------------------------------------------------
+-// Functions from PipeWire used in capturer code.
+-//------------------------------------------------
+-
+-// core.h
+-void pw_core_destroy(pw_core *core);
+-pw_type *pw_core_get_type(pw_core *core);
+-pw_core * pw_core_new(pw_loop *main_loop, pw_properties *props);
+-
+-// loop.h
+-void pw_loop_destroy(pw_loop *loop);
+-pw_loop * pw_loop_new(pw_properties *properties);
+-
+-// pipewire.h
+-void pw_init(int *argc, char **argv[]);
+-
+-// properties.h
+-pw_properties * pw_properties_new_string(const char *args);
+-
+-// remote.h
+-void pw_remote_add_listener(pw_remote *remote, spa_hook *listener, const pw_remote_events *events, void *data);
+-int pw_remote_connect_fd(pw_remote *remote, int fd);
+-void pw_remote_destroy(pw_remote *remote);
+-pw_remote * pw_remote_new(pw_core *core, pw_properties *properties, size_t user_data_size);
+-
+-// stream.h
+-void pw_stream_add_listener(pw_stream *stream, spa_hook *listener, const pw_stream_events *events, void *data);
+-int pw_stream_connect(pw_stream *stream, enum pw_direction direction, const char *port_path, enum pw_stream_flags flags, const spa_pod **params, uint32_t n_params);
+-pw_buffer *pw_stream_dequeue_buffer(pw_stream *stream);
+-void pw_stream_destroy(pw_stream *stream);
+-void pw_stream_finish_format(pw_stream *stream, int res, const spa_pod **params, uint32_t n_params);
+-pw_stream * pw_stream_new(pw_remote *remote, const char *name, pw_properties *props);
+-int pw_stream_queue_buffer(pw_stream *stream, pw_buffer *buffer);
+-int pw_stream_set_active(pw_stream *stream, bool active);
+-
+-// thread-loop.h
+-void pw_thread_loop_destroy(pw_thread_loop *loop);
+-pw_thread_loop * pw_thread_loop_new(pw_loop *loop, const char *name);
+-int pw_thread_loop_start(pw_thread_loop *loop);
+-void pw_thread_loop_stop(pw_thread_loop *loop);
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.cc b/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.cc
+deleted file mode 100644
+index fe672140cca..00000000000
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.cc
++++ /dev/null
+@@ -1,29 +0,0 @@
+-/*
+- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+- *
+- *  Use of this source code is governed by a BSD-style license
+- *  that can be found in the LICENSE file in the root of the source
+- *  tree. An additional intellectual property rights grant can be found
+- *  in the file PATENTS.  All contributing project authors may
+- *  be found in the AUTHORS file in the root of the source tree.
+- */
+-
+-#include "modules/desktop_capture/linux/screen_capturer_pipewire.h"
+-
+-#include <memory>
+-
+-
+-namespace webrtc {
+-
+-ScreenCapturerPipeWire::ScreenCapturerPipeWire()
+-    : BaseCapturerPipeWire(BaseCapturerPipeWire::CaptureSourceType::Screen) {}
+-ScreenCapturerPipeWire::~ScreenCapturerPipeWire() {}
+-
+-// static
+-std::unique_ptr<DesktopCapturer>
+-ScreenCapturerPipeWire::CreateRawScreenCapturer(
+-    const DesktopCaptureOptions& options) {
+-  return std::make_unique<ScreenCapturerPipeWire>();
+-}
+-
+-}  // namespace webrtc
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.h b/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.h
+deleted file mode 100644
+index 66dcd680e06..00000000000
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/screen_capturer_pipewire.h
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+- *
+- *  Use of this source code is governed by a BSD-style license
+- *  that can be found in the LICENSE file in the root of the source
+- *  tree. An additional intellectual property rights grant can be found
+- *  in the file PATENTS.  All contributing project authors may
+- *  be found in the AUTHORS file in the root of the source tree.
+- */
+-
+-#ifndef MODULES_DESKTOP_CAPTURE_LINUX_SCREEN_CAPTURER_PIPEWIRE_H_
+-#define MODULES_DESKTOP_CAPTURE_LINUX_SCREEN_CAPTURER_PIPEWIRE_H_
+-
+-#include <memory>
+-
+-#include "modules/desktop_capture/linux/base_capturer_pipewire.h"
+-
+-namespace webrtc {
+-
+-class ScreenCapturerPipeWire : public BaseCapturerPipeWire {
+- public:
+-  ScreenCapturerPipeWire();
+-  ~ScreenCapturerPipeWire() override;
+-
+-  static std::unique_ptr<DesktopCapturer> CreateRawScreenCapturer(
+-      const DesktopCaptureOptions& options);
+-
+-  RTC_DISALLOW_COPY_AND_ASSIGN(ScreenCapturerPipeWire);
+-};
+-
+-}  // namespace webrtc
+-
+-#endif  // MODULES_DESKTOP_CAPTURE_LINUX_SCREEN_CAPTURER_PIPEWIRE_H_
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.cc b/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.cc
+deleted file mode 100644
+index b4559156dce..00000000000
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.cc
++++ /dev/null
+@@ -1,29 +0,0 @@
+-/*
+- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+- *
+- *  Use of this source code is governed by a BSD-style license
+- *  that can be found in the LICENSE file in the root of the source
+- *  tree. An additional intellectual property rights grant can be found
+- *  in the file PATENTS.  All contributing project authors may
+- *  be found in the AUTHORS file in the root of the source tree.
+- */
+-
+-#include "modules/desktop_capture/linux/window_capturer_pipewire.h"
+-
+-#include <memory>
+-
+-
+-namespace webrtc {
+-
+-WindowCapturerPipeWire::WindowCapturerPipeWire()
+-    : BaseCapturerPipeWire(BaseCapturerPipeWire::CaptureSourceType::Window) {}
+-WindowCapturerPipeWire::~WindowCapturerPipeWire() {}
+-
+-// static
+-std::unique_ptr<DesktopCapturer>
+-WindowCapturerPipeWire::CreateRawWindowCapturer(
+-    const DesktopCaptureOptions& options) {
+-  return std::make_unique<WindowCapturerPipeWire>();
+-}
+-
+-}  // namespace webrtc
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.h b/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.h
+deleted file mode 100644
+index 7f184ef2999..00000000000
+--- a/chromium/third_party/webrtc/modules/desktop_capture/linux/window_capturer_pipewire.h
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+- *  Copyright 2018 The WebRTC project authors. All Rights Reserved.
+- *
+- *  Use of this source code is governed by a BSD-style license
+- *  that can be found in the LICENSE file in the root of the source
+- *  tree. An additional intellectual property rights grant can be found
+- *  in the file PATENTS.  All contributing project authors may
+- *  be found in the AUTHORS file in the root of the source tree.
+- */
+-
+-#ifndef MODULES_DESKTOP_CAPTURE_LINUX_WINDOW_CAPTURER_PIPEWIRE_H_
+-#define MODULES_DESKTOP_CAPTURE_LINUX_WINDOW_CAPTURER_PIPEWIRE_H_
+-
+-#include <memory>
+-
+-#include "modules/desktop_capture/linux/base_capturer_pipewire.h"
+-
+-namespace webrtc {
+-
+-class WindowCapturerPipeWire : public BaseCapturerPipeWire {
+- public:
+-  WindowCapturerPipeWire();
+-  ~WindowCapturerPipeWire() override;
+-
+-  static std::unique_ptr<DesktopCapturer> CreateRawWindowCapturer(
+-      const DesktopCaptureOptions& options);
+-
+-  RTC_DISALLOW_COPY_AND_ASSIGN(WindowCapturerPipeWire);
+-};
+-
+-}  // namespace webrtc
+-
+-#endif  // MODULES_DESKTOP_CAPTURE_LINUX_WINDOW_CAPTURER_PIPEWIRE_H_
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/screen_capturer_linux.cc b/chromium/third_party/webrtc/modules/desktop_capture/screen_capturer_linux.cc
+index 82dbae48137..ed48b7d6d59 100644
+--- a/chromium/third_party/webrtc/modules/desktop_capture/screen_capturer_linux.cc
++++ b/chromium/third_party/webrtc/modules/desktop_capture/screen_capturer_linux.cc
+@@ -14,7 +14,7 @@
+ #include "modules/desktop_capture/desktop_capturer.h"
+ 
+ #if defined(WEBRTC_USE_PIPEWIRE)
+-#include "modules/desktop_capture/linux/screen_capturer_pipewire.h"
++#include "modules/desktop_capture/linux/base_capturer_pipewire.h"
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+ #if defined(WEBRTC_USE_X11)
+@@ -28,7 +28,7 @@ std::unique_ptr<DesktopCapturer> DesktopCapturer::CreateRawScreenCapturer(
+     const DesktopCaptureOptions& options) {
+ #if defined(WEBRTC_USE_PIPEWIRE)
+   if (options.allow_pipewire() && DesktopCapturer::IsRunningUnderWayland()) {
+-    return ScreenCapturerPipeWire::CreateRawScreenCapturer(options);
++    return BaseCapturerPipeWire::CreateRawCapturer(options);
+   }
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/window_capturer_linux.cc b/chromium/third_party/webrtc/modules/desktop_capture/window_capturer_linux.cc
+index 41dbf836b03..2b142ae3b92 100644
+--- a/chromium/third_party/webrtc/modules/desktop_capture/window_capturer_linux.cc
++++ b/chromium/third_party/webrtc/modules/desktop_capture/window_capturer_linux.cc
+@@ -14,7 +14,7 @@
+ #include "modules/desktop_capture/desktop_capturer.h"
+ 
+ #if defined(WEBRTC_USE_PIPEWIRE)
+-#include "modules/desktop_capture/linux/window_capturer_pipewire.h"
++#include "modules/desktop_capture/linux/base_capturer_pipewire.h"
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+ #if defined(WEBRTC_USE_X11)
+@@ -28,7 +28,7 @@ std::unique_ptr<DesktopCapturer> DesktopCapturer::CreateRawWindowCapturer(
+     const DesktopCaptureOptions& options) {
+ #if defined(WEBRTC_USE_PIPEWIRE)
+   if (options.allow_pipewire() && DesktopCapturer::IsRunningUnderWayland()) {
+-    return WindowCapturerPipeWire::CreateRawWindowCapturer(options);
++    return BaseCapturerPipeWire::CreateRawCapturer(options);
+   }
+ #endif  // defined(WEBRTC_USE_PIPEWIRE)
+ 
+diff --git a/chromium/third_party/webrtc/webrtc.gni b/chromium/third_party/webrtc/webrtc.gni
+index ca8acdbf259..505c975cece 100644
+--- a/chromium/third_party/webrtc/webrtc.gni
++++ b/chromium/third_party/webrtc/webrtc.gni
+@@ -117,6 +117,10 @@ declare_args() {
+   # Set this to link PipeWire directly instead of using the dlopen.
+   rtc_link_pipewire = false
+ 
++  # Set this to use certain PipeWire version
++  # Currently we support PipeWire 0.2 (default) and PipeWire 0.3
++  rtc_pipewire_version = "0.3"
++
+   # Enable to use the Mozilla internal settings.
+   build_with_mozilla = false
+ 
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire02.sigs b/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire02.sigs
+new file mode 100644
+index 00000000000..5ac3d1d22b8
+--- /dev/null
++++ b/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire02.sigs
+@@ -0,0 +1,47 @@
++// Copyright 2018 The WebRTC project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++//------------------------------------------------
++// Functions from PipeWire used in capturer code.
++//------------------------------------------------
++
++// core.h
++void pw_core_destroy(pw_core *core);
++pw_type *pw_core_get_type(pw_core *core);
++pw_core * pw_core_new(pw_loop *main_loop, pw_properties *props);
++
++// loop.h
++void pw_loop_destroy(pw_loop *loop);
++pw_loop * pw_loop_new(pw_properties *properties);
++
++// pipewire.h
++void pw_init(int *argc, char **argv[]);
++
++// properties.h
++pw_properties * pw_properties_new_string(const char *args);
++
++// remote.h
++void pw_remote_add_listener(pw_remote *remote, spa_hook *listener, const pw_remote_events *events, void *data);
++int pw_remote_connect_fd(pw_remote *remote, int fd);
++void pw_remote_destroy(pw_remote *remote);
++pw_remote * pw_remote_new(pw_core *core, pw_properties *properties, size_t user_data_size);
++enum pw_remote_state pw_remote_get_state(pw_remote *remote, const char **error);
++
++// stream.h
++void pw_stream_add_listener(pw_stream *stream, spa_hook *listener, const pw_stream_events *events, void *data);
++int pw_stream_connect(pw_stream *stream, enum pw_direction direction, const char *port_path, enum pw_stream_flags flags, const spa_pod **params, uint32_t n_params);
++pw_buffer *pw_stream_dequeue_buffer(pw_stream *stream);
++void pw_stream_destroy(pw_stream *stream);
++void pw_stream_finish_format(pw_stream *stream, int res, const spa_pod **params, uint32_t n_params);
++pw_stream * pw_stream_new(pw_remote *remote, const char *name, pw_properties *props);
++int pw_stream_queue_buffer(pw_stream *stream, pw_buffer *buffer);
++int pw_stream_set_active(pw_stream *stream, bool active);
++
++// thread-loop.h
++void pw_thread_loop_destroy(pw_thread_loop *loop);
++pw_thread_loop * pw_thread_loop_new(pw_loop *loop, const char *name);
++int pw_thread_loop_start(pw_thread_loop *loop);
++void pw_thread_loop_stop(pw_thread_loop *loop);
++void pw_thread_loop_lock(struct pw_thread_loop *loop);
++void pw_thread_loop_unlock(struct pw_thread_loop *loop);
+diff --git a/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire03.sigs b/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire03.sigs
+new file mode 100644
+index 00000000000..78d241f40c6
+--- /dev/null
++++ b/chromium/third_party/webrtc/modules/desktop_capture/linux/pipewire03.sigs
+@@ -0,0 +1,46 @@
++// Copyright 2018 The WebRTC project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++//------------------------------------------------
++// Functions from PipeWire used in capturer code.
++//------------------------------------------------
++
++// core.h
++int pw_core_disconnect(pw_core *core);
++
++// loop.h
++void pw_loop_destroy(pw_loop *loop);
++pw_loop * pw_loop_new(const spa_dict *props);
++
++
++// pipewire.h
++void pw_init(int *argc, char **argv[]);
++
++// properties.h
++pw_properties * pw_properties_new_string(const char *args);
++
++// stream.h
++void pw_stream_add_listener(pw_stream *stream, spa_hook *listener, const pw_stream_events *events, void *data);
++int pw_stream_connect(pw_stream *stream, enum pw_direction direction, uint32_t target_id, enum pw_stream_flags flags, const spa_pod **params, uint32_t n_params);
++pw_buffer *pw_stream_dequeue_buffer(pw_stream *stream);
++void pw_stream_destroy(pw_stream *stream);
++pw_stream * pw_stream_new(pw_core *core, const char *name, pw_properties *props);
++int pw_stream_queue_buffer(pw_stream *stream, pw_buffer *buffer);
++int pw_stream_set_active(pw_stream *stream, bool active);
++int pw_stream_update_params(pw_stream *stream, const spa_pod **params, uint32_t n_params);
++
++// thread-loop.h
++void pw_thread_loop_destroy(pw_thread_loop *loop);
++pw_thread_loop * pw_thread_loop_new(const char *name, const spa_dict *props);
++int pw_thread_loop_start(pw_thread_loop *loop);
++void pw_thread_loop_stop(pw_thread_loop *loop);
++void pw_thread_loop_lock(pw_thread_loop *loop);
++void pw_thread_loop_unlock(pw_thread_loop *loop);
++pw_loop * pw_thread_loop_get_loop(pw_thread_loop *loop);
++
++
++// context.h
++void pw_context_destroy(pw_context *context);
++pw_context *pw_context_new(pw_loop *main_loop, pw_properties *props, size_t user_data_size);
++pw_core * pw_context_connect(pw_context *context, pw_properties *properties, size_t user_data_size);

--- a/qt5-webengine/qt5-webengine-python3.patch
+++ b/qt5-webengine/qt5-webengine-python3.patch
@@ -1,0 +1,161 @@
+diff --git a/configure.pri b/configure.pri
+index 8705ad93..6723bffe 100644
+--- a/configure.pri
++++ b/configure.pri
+@@ -7,20 +7,7 @@ QTWEBENGINE_SOURCE_TREE = $$PWD
+ equals(QMAKE_HOST.os, Windows): EXE_SUFFIX = .exe
+ 
+ defineTest(isPythonVersionSupported) {
+-    python = $$system_quote($$system_path($$1))
+-    python_version = $$system('$$python -c "import sys; print(sys.version_info[0:3])"')
+-    python_version ~= s/[()]//g
+-    python_version = $$split(python_version, ',')
+-    python_major_version = $$first(python_version)
+-    greaterThan(python_major_version, 2) {
+-        qtLog("Python version 3 is not supported by Chromium.")
+-        return(false)
+-    }
+-    python_minor_version = $$member(python_version, 1)
+-    python_patch_version = $$member(python_version, 2)
+-    greaterThan(python_major_version, 1): greaterThan(python_minor_version, 6): greaterThan(python_patch_version, 4): return(true)
+-    qtLog("Unsupported python version: $${python_major_version}.$${python_minor_version}.$${python_patch_version}.")
+-    return(false)
++    return(true)
+ }
+ 
+ defineTest(qtConfTest_detectJumboBuild) {
+@@ -52,10 +48,10 @@ defineTest(qtConfReport_jumboBuild) {
+     qtConfReportPadded($${1}, $$mergeLimit)
+ }
+ 
+-defineTest(qtConfTest_detectPython2) {
+-    python = $$qtConfFindInPath("python2$$EXE_SUFFIX")
++defineTest(qtConfTest_detectPython) {
++    python = $$qtConfFindInPath("python$$EXE_SUFFIX")
+     isEmpty(python) {
+-        qtLog("'python2$$EXE_SUFFIX' not found in PATH. Checking for 'python$$EXE_SUFFIX'.")
++        qtLog("'python$$EXE_SUFFIX' not found in PATH. Checking for 'python$$EXE_SUFFIX'.")
+         python = $$qtConfFindInPath("python$$EXE_SUFFIX")
+     }
+     isEmpty(python) {
+@@ -63,11 +59,11 @@ defineTest(qtConfTest_detectPython2) {
+         return(false)
+     }
+     !isPythonVersionSupported($$python) {
+-        qtLog("A suitable Python 2 executable could not be located.")
++        qtLog("A suitable Python executable could not be located.")
+         return(false)
+     }
+ 
+-    # Make tests.python2.location available in configure.json.
++    # Make tests.python.location available in configure.json.
+     $${1}.location = $$clean_path($$python)
+     export($${1}.location)
+     $${1}.cache += location
+diff --git a/mkspecs/features/functions.prf b/mkspecs/features/functions.prf
+index 2750d707..9fda13d0 100644
+--- a/mkspecs/features/functions.prf
++++ b/mkspecs/features/functions.prf
+@@ -39,11 +39,11 @@ defineReplace(which) {
+ 
+ # Returns the unquoted path to the python executable.
+ defineReplace(pythonPath) {
+-    isEmpty(QMAKE_PYTHON2) {
++    isEmpty(QMAKE_PYTHON) {
+         # Fallback for building QtWebEngine with Qt < 5.8
+-        QMAKE_PYTHON2 = python
++        QMAKE_PYTHON = python
+     }
+-    return($$QMAKE_PYTHON2)
++    return($$QMAKE_PYTHON)
+ }
+ 
+ # Returns the python executable for use with shell / make targets.
+diff --git a/src/buildtools/config/support.pri b/src/buildtools/config/support.pri
+index e7f869a1..1bf2c5d7 100644
+--- a/src/buildtools/config/support.pri
++++ b/src/buildtools/config/support.pri
+@@ -21,7 +21,7 @@ defineReplace(qtwebengine_checkWebEngineCoreError) {
+     !qtwebengine_checkForGperf(QtWebEngine):return(false)
+     !qtwebengine_checkForBison(QtWebEngine):return(false)
+     !qtwebengine_checkForFlex(QtWebEngine):return(false)
+-    !qtwebengine_checkForPython2(QtWebEngine):return(false)
++    !qtwebengine_checkForPython(QtWebEngine):return(false)
+     !qtwebengine_checkForNodejs(QtWebEngine):return(false)
+     !qtwebengine_checkForSanitizer(QtWebEngine):return(false)
+     linux:!qtwebengine_checkForPkgCfg(QtWebEngine):return(false)
+@@ -51,7 +51,7 @@ defineReplace(qtwebengine_checkPdfError) {
+     !qtwebengine_checkForGperf(QtPdf):return(false)
+     !qtwebengine_checkForBison(QtPdf):return(false)
+     !qtwebengine_checkForFlex(QtPdf):return(false)
+-    !qtwebengine_checkForPython2(QtPdf):return(false)
++    !qtwebengine_checkForPython(QtPdf):return(false)
+     !qtwebengine_checkForSanitizer(QtPdf):return(false)
+     linux:!qtwebengine_checkForPkgCfg(QtPdf):return(false)
+     linux:!qtwebengine_checkForHostPkgCfg(QtPdf):return(false)
+@@ -143,10 +143,10 @@ defineTest(qtwebengine_checkForFlex) {
+     return(true)
+ }
+ 
+-defineTest(qtwebengine_checkForPython2) {
++defineTest(qtwebengine_checkForPython) {
+     module = $$1
+-    !qtConfig(webengine-python2) {
+-        qtwebengine_skipBuild("Python version 2 (2.7.5 or later) is required to build $${module}.")
++    !qtConfig(webengine-python) {
++        qtwebengine_skipBuild("Python is required to build $${module}.")
+         return(false)
+     }
+     return(true)
+diff --git a/src/buildtools/configure.json b/src/buildtools/configure.json
+index 88d1790c..032aa665 100644
+--- a/src/buildtools/configure.json
++++ b/src/buildtools/configure.json
+@@ -295,9 +295,9 @@
+             "label": "system ninja",
+             "type": "detectNinja"
+         },
+-        "webengine-python2": {
+-            "label": "python2",
+-            "type": "detectPython2",
++        "webengine-python": {
++            "label": "python",
++            "type": "detectPython",
+             "log": "location"
+         },
+         "webengine-winversion": {
+@@ -374,7 +374,7 @@
+                          && features.webengine-gperf
+                          && features.webengine-bison
+                          && features.webengine-flex
+-                         && features.webengine-python2
++                         && features.webengine-python
+                          && features.webengine-nodejs
+                          && (!config.sanitizer || features.webengine-sanitizer)
+                          && (!config.linux || features.pkg-config)
+@@ -400,7 +400,7 @@
+                          && features.webengine-gperf
+                          && features.webengine-bison
+                          && features.webengine-flex
+-                         && features.webengine-python2
++                         && features.webengine-python
+                          && (!config.sanitizer || features.webengine-sanitizer)
+                          && (!config.linux || features.pkg-config)
+                          && (!config.linux || features.webengine-host-pkg-config)
+@@ -423,12 +423,12 @@
+             "autoDetect": "features.private_tests",
+             "output": [ "privateFeature" ]
+         },
+-        "webengine-python2": {
+-            "label": "python2",
+-            "condition": "tests.webengine-python2",
++        "webengine-python": {
++            "label": "python",
++            "condition": "tests.webengine-python",
+             "output": [
+                 "privateFeature",
+-                { "type": "varAssign", "name": "QMAKE_PYTHON2", "value": "tests.webengine-python2.location" }
++                { "type": "varAssign", "name": "QMAKE_PYTHON", "value": "tests.webengine-python.location" }
+             ]
+         },
+         "webengine-gperf": {

--- a/qt5-webengine/skia-harfbuzz-3.0.0.patch
+++ b/qt5-webengine/skia-harfbuzz-3.0.0.patch
@@ -1,0 +1,100 @@
+# Minimal diff for harfbuzz 3.0.0 support; based on:
+# https://github.com/google/skia/commit/66684b17b382
+# https://github.com/google/skia/commit/51d83abcd24a
+
+diff --git a/gn/skia.gni b/gn/skia.gni
+index d98fdc19ee..199335d5c4 100644
+--- a/gn/skia.gni
++++ b/gn/skia.gni
+@@ -34,8 +34,6 @@ declare_args() {
+   skia_include_multiframe_procs = false
+   skia_lex = false
+   skia_libgifcodec_path = "third_party/externals/libgifcodec"
+-  skia_pdf_subset_harfbuzz =
+-      false  # TODO: set skia_pdf_subset_harfbuzz to skia_use_harfbuzz.
+   skia_qt_path = getenv("QT_PATH")
+   skia_skqp_global_error_tolerance = 0
+   skia_tools_require_resources = false
+@@ -99,6 +97,10 @@ declare_args() {
+   skia_use_libfuzzer_defaults = true
+ }
+ 
++declare_args() {
++  skia_pdf_subset_harfbuzz = skia_use_harfbuzz
++}
++
+ declare_args() {
+   skia_compile_sksl_tests = skia_compile_processors
+   skia_enable_fontmgr_android = skia_use_expat && skia_use_freetype
+diff --git a/src/pdf/SkPDFSubsetFont.cpp b/src/pdf/SkPDFSubsetFont.cpp
+index 81c37eef3a..2340a7937b 100644
+--- a/src/pdf/SkPDFSubsetFont.cpp
++++ b/src/pdf/SkPDFSubsetFont.cpp
+@@ -49,6 +49,37 @@ static sk_sp<SkData> to_data(HBBlob blob) {
+                                 blob.release());
+ }
+ 
++template<typename...> using void_t = void;
++template<typename T, typename = void>
++struct SkPDFHarfBuzzSubset {
++    // This is the HarfBuzz 3.0 interface.
++    // hb_subset_flags_t does not exist in 2.0. It isn't dependent on T, so inline the value of
++    // HB_SUBSET_FLAGS_RETAIN_GIDS until 2.0 is no longer supported.
++    static HBFace Make(T input, hb_face_t* face) {
++        // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
++        // If it isn't known if a font is 'tricky', retain the hints.
++        hb_subset_input_set_flags(input, 2/*HB_SUBSET_FLAGS_RETAIN_GIDS*/);
++        return HBFace(hb_subset_or_fail(face, input));
++    }
++};
++template<typename T>
++struct SkPDFHarfBuzzSubset<T, void_t<
++    decltype(hb_subset_input_set_retain_gids(std::declval<T>(), std::declval<bool>())),
++    decltype(hb_subset_input_set_drop_hints(std::declval<T>(), std::declval<bool>())),
++    decltype(hb_subset(std::declval<hb_face_t*>(), std::declval<T>()))
++    >>
++{
++    // This is the HarfBuzz 2.0 (non-public) interface, used if it exists.
++    // This code should be removed as soon as all users are migrated to the newer API.
++    static HBFace Make(T input, hb_face_t* face) {
++        hb_subset_input_set_retain_gids(input, true);
++        // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
++        // If it isn't known if a font is 'tricky', retain the hints.
++        hb_subset_input_set_drop_hints(input, false);
++        return HBFace(hb_subset(face, input));
++    }
++};
++
+ static sk_sp<SkData> subset_harfbuzz(sk_sp<SkData> fontData,
+                                      const SkPDFGlyphUse& glyphUsage,
+                                      int ttcIndex) {
+@@ -71,11 +102,10 @@ static sk_sp<SkData> subset_harfbuzz(sk_sp<SkData> fontData,
+     hb_set_t* glyphs = hb_subset_input_glyph_set(input.get());
+     glyphUsage.getSetValues([&glyphs](unsigned gid) { hb_set_add(glyphs, gid);});
+ 
+-    hb_subset_input_set_retain_gids(input.get(), true);
+-    // TODO: When possible, check if a font is 'tricky' with FT_IS_TRICKY.
+-    // If it isn't known if a font is 'tricky', retain the hints.
+-    hb_subset_input_set_drop_hints(input.get(), false);
+-    HBFace subset(hb_subset(face.get(), input.get()));
++    HBFace subset = SkPDFHarfBuzzSubset<hb_subset_input_t*>::Make(input.get(), face.get());
++    if (!subset) {
++        return nullptr;
++    }
+     HBBlob result(hb_face_reference_blob(subset.get()));
+     return to_data(std::move(result));
+ }
+diff --git a/third_party/harfbuzz/BUILD.gn b/third_party/harfbuzz/BUILD.gn
+index 173830de62..4156607ef9 100644
+--- a/third_party/harfbuzz/BUILD.gn
++++ b/third_party/harfbuzz/BUILD.gn
+@@ -14,6 +14,9 @@ if (skia_use_system_harfbuzz) {
+   system("harfbuzz") {
+     include_dirs = [ "/usr/include/harfbuzz" ]
+     libs = [ "harfbuzz" ]
++    if (skia_pdf_subset_harfbuzz) {
++      libs += [ "harfbuzz-subset" ]
++    }
+   }
+ } else {
+   third_party("harfbuzz") {

--- a/qt6-webengine/0001-ARM-toolchain-fixes.patch
+++ b/qt6-webengine/0001-ARM-toolchain-fixes.patch
@@ -1,0 +1,58 @@
+From 46dc6b6a276e974341328f78451678d756c382f9 Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Tue, 4 Jul 2017 11:54:39 -0600
+Subject: [PATCH 1/2] ARM toolchain fixes
+
+---
+ chromium/build/toolchain/linux/BUILD.gn | 24 ++++++++++--------------
+ 1 file changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/chromium/build/toolchain/linux/BUILD.gn b/chromium/build/toolchain/linux/BUILD.gn
+index 0c0b0a3321e..fa147fa5667 100644
+--- a/chromium/build/toolchain/linux/BUILD.gn
++++ b/chromium/build/toolchain/linux/BUILD.gn
+@@ -31,15 +31,13 @@ clang_toolchain("clang_arm64") {
+ }
+ 
+ gcc_toolchain("arm64") {
+-  toolprefix = "aarch64-linux-gnu-"
+-
+-  cc = "${toolprefix}gcc"
+-  cxx = "${toolprefix}g++"
++  cc = "gcc"
++  cxx = "g++"
+ 
+-  ar = "${toolprefix}ar"
++  ar = "ar"
+   ld = cxx
+-  readelf = "${toolprefix}readelf"
+-  nm = "${toolprefix}nm"
++  readelf = "readelf"
++  nm = "nm"
+ 
+   toolchain_args = {
+     current_cpu = "arm64"
+@@ -52,15 +50,13 @@ gcc_toolchain("arm64") {
+ }
+ 
+ gcc_toolchain("arm") {
+-  toolprefix = "arm-linux-gnueabihf-"
+-
+-  cc = "${toolprefix}gcc"
+-  cxx = "${toolprefix}g++"
++  cc = "gcc"
++  cxx = "g++"
+ 
+-  ar = "${toolprefix}ar"
++  ar = "ar"
+   ld = cxx
+-  readelf = "${toolprefix}readelf"
+-  nm = "${toolprefix}nm"
++  readelf = "readelf"
++  nm = "nm"
+ 
+   toolchain_args = {
+     current_cpu = "arm"
+-- 
+2.35.1
+

--- a/qt6-webengine/0002-Run-blink-bindings-generation-single-threaded.patch
+++ b/qt6-webengine/0002-Run-blink-bindings-generation-single-threaded.patch
@@ -1,0 +1,25 @@
+From 8b1d4ec4b3f5c569eef9d8e5d40cb0e961d6ba31 Mon Sep 17 00:00:00 2001
+From: Kevin Mihelich <kevin@archlinuxarm.org>
+Date: Tue, 2 Feb 2021 13:58:59 -0700
+Subject: [PATCH 2/2] Run blink bindings generation single threaded
+
+When not single threaded this process will eat all the RAM.
+---
+ chromium/third_party/blink/renderer/bindings/BUILD.gn | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chromium/third_party/blink/renderer/bindings/BUILD.gn b/chromium/third_party/blink/renderer/bindings/BUILD.gn
+index 30017570a13..f88e5906f23 100644
+--- a/chromium/third_party/blink/renderer/bindings/BUILD.gn
++++ b/chromium/third_party/blink/renderer/bindings/BUILD.gn
+@@ -148,6 +148,7 @@ template("generate_bindings") {
+     outputs = invoker.outputs
+ 
+     args = [
++      "--single_process",
+       "--web_idl_database",
+       rebase_path(web_idl_database, root_build_dir),
+       "--root_src_dir",
+-- 
+2.35.1
+

--- a/qt6-webengine/PKGBUILD
+++ b/qt6-webengine/PKGBUILD
@@ -1,0 +1,67 @@
+# Maintainer: Antonio Rojas <arojas@archlinux.org>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+# ALARM: Kevin Mihelich <kevin@archlinuxarm.org>
+#  - patch for chromium GN
+#  - patch for chromium skia
+#  - patch for chromium to run blink bindings generation single threaded
+#  - patch for chromium aw snap on ARM
+#  - restrict job count on v7 - RAM constraints
+
+highmem=1
+
+pkgname=qt6-webengine
+_qtver=6.3.1
+pkgver=${_qtver/-/}
+pkgrel=2
+arch=(x86_64)
+url='https://www.qt.io'
+license=(GPL3 LGPL3 FDL custom)
+pkgdesc='Provides support for web applications using the Chromium browser project'
+depends=(qt6-webchannel qt6-positioning libxcomposite libxrandr libxkbfile 
+         libevent snappy nss libxslt minizip ffmpeg re2 libvpx libxtst ttf-font pciutils)
+makedepends=(cmake ninja python-html5lib gperf jsoncpp qt6-tools pipewire nodejs qt6-websockets)
+optdepends=('pipewire: WebRTC desktop sharing under Wayland')
+groups=(qt6)
+options=(debug)
+_pkgfn=${pkgname/6-/}-everywhere-src-$_qtver
+source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz
+        0001-ARM-toolchain-fixes.patch
+        0002-Run-blink-bindings-generation-single-threaded.patch
+        qt6-webengine-16kpage.patch)
+sha256sums=('ad7a33b21a956deda37c587d50f821ca3816403ae31ba9b5d59d01561ad66e47'
+            'c5d8fc6b3b832a2b4b14c926c36051d7245d5fc37a1c3a54657afd5b5c4ed623'
+            '1a5858dd198dd0db649c55357941c9bfa9ad678b5d4b93121f87fa9f314d4e6e'
+            '82fca8551849ac95d1aa7f22e2c1a9c191a198ed48b806ac1517704c3c68d1ad')
+
+prepare() {
+  cd $_pkgfn
+
+  if [[ $CARCH == "armv7h" ]]; then
+    export MAKEFLAGS="-j4"
+    export ALARM_NINJA_JOBS="2"
+  fi
+  cd "$srcdir/$_pkgfn/src/3rdparty"
+  patch -p1 -i ${srcdir}/0001-ARM-toolchain-fixes.patch
+  patch -p1 -i ${srcdir}/0002-Run-blink-bindings-generation-single-threaded.patch
+}
+
+build() {
+  cmake -B build -S $_pkgfn -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE=/usr/lib/cmake/Qt6/qt.toolchain.cmake \
+    -DQT_FEATURE_webengine_system_ffmpeg=ON \
+    -DQT_FEATURE_webengine_system_icu=ON \
+    -DQT_FEATURE_webengine_system_libevent=ON \
+    -DQT_FEATURE_webengine_system_libxslt=ON \
+    -DQT_FEATURE_webengine_proprietary_codecs=ON \
+    -DQT_FEATURE_webengine_kerberos=ON \
+    -DQT_FEATURE_webengine_webrtc_pipewire=ON \
+    -DQT_FEATURE_webengine_full_debug_info=ON
+  cmake --build build
+}
+
+package() {
+  DESTDIR="$pkgdir" cmake --install build
+
+  install -Dm644 "$srcdir"/${_pkgfn}/src/3rdparty/chromium/LICENSE "$pkgdir"/usr/share/licenses/${pkgname}/LICENSE.chromium
+}

--- a/qt6-webengine/qt6-webengine-16kpage.patch
+++ b/qt6-webengine/qt6-webengine-16kpage.patch
@@ -1,0 +1,347 @@
+From dbd3230a23a202a90e1cb104c403cdb72e248e82 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Thu, 21 Jul 2022 06:42:07 -0400
+Subject: [PATCH] Backport of 16k page support on aarch64
+
+---
+ .../address_space_randomization.h             | 15 ++++++
+ .../page_allocator_constants.h                | 50 +++++++++++++++++-
+ .../partition_address_space.cc                |  6 +++
+ .../partition_alloc_constants.h               |  5 +-
+ .../partition_allocator/partition_root.cc     |  2 +-
+ .../address_space_randomization.h             | 15 ++++++
+ .../partition_allocator/page_allocator.cc     |  8 +++
+ .../page_allocator_constants.h                | 52 ++++++++++++++++++-
+ .../partition_allocator/partition_alloc.cc    |  2 +-
+ .../partition_alloc_constants.h               |  5 +-
+ 10 files changed, 152 insertions(+), 8 deletions(-)
+
+diff --git a/chromium/base/allocator/partition_allocator/address_space_randomization.h b/chromium/base/allocator/partition_allocator/address_space_randomization.h
+index e77003eab25..31ac05b86f5 100644
+--- a/chromium/base/allocator/partition_allocator/address_space_randomization.h
++++ b/chromium/base/allocator/partition_allocator/address_space_randomization.h
+@@ -119,6 +119,21 @@ AslrMask(uintptr_t bits) {
+         return AslrAddress(0x20000000ULL);
+       }
+ 
++      #elif defined(OS_LINUX)
++
++      // Linux on arm64 can use 39, 42, 48, or 52-bit user space, depending on
++      // page size and number of levels of translation pages used. We use
++      // 39-bit as base as all setups should support this, lowered to 38-bit
++      // as ASLROffset() could cause a carry.
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLRMask() {
++        return AslrMask(38);
++      }
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLROffset() {
++        return AslrAddress(0x1000000000ULL);
++      }
++
+       #else
+ 
+       // ARM64 on Linux has 39-bit user space. Use 38 bits since ASLROffset()
+diff --git a/chromium/base/allocator/partition_allocator/page_allocator_constants.h b/chromium/base/allocator/partition_allocator/page_allocator_constants.h
+index f6f19e41611..200903d3342 100644
+--- a/chromium/base/allocator/partition_allocator/page_allocator_constants.h
++++ b/chromium/base/allocator/partition_allocator/page_allocator_constants.h
+@@ -24,6 +24,31 @@
+ // elimination.
+ #define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
+ 
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++// This should work for all POSIX (if needed), but currently all other
++// supported OS/architecture combinations use either hard-coded values
++// (such as x86) or have means to determine these values without needing
++// atomics (such as macOS on arm64).
++
++// Page allocator constants are run-time constant
++#define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
++
++#include <unistd.h>
++#include <atomic>
++
++namespace base::internal {
++
++// Holds the current page size and shift, where size = 1 << shift
++// Use PageAllocationGranularity(), PageAllocationGranularityShift()
++// to initialize and retrieve these values safely.
++struct PageCharacteristics {
++  std::atomic<int> size;
++  std::atomic<int> shift;
++};
++extern PageCharacteristics page_characteristics;
++
++}  // namespace partition_alloc::internal
++
+ #else
+ 
+ // When defined, page size constants are fixed at compile time. When not
+@@ -38,6 +63,10 @@
+ 
+ namespace base {
+ 
++// Forward declaration, implementation below
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
++PageAllocationGranularity();
++
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PageAllocationGranularityShift() {
+ #if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+@@ -50,6 +79,15 @@ PageAllocationGranularityShift() {
+   return 14;  // 16kB
+ #elif defined(OS_APPLE) && defined(ARCH_CPU_64_BITS)
+   return vm_page_shift;
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb (shift = 12), 16kb (shift = 14), and 64kb (shift = 16)
++  // page sizes. Retrieve from or initialize cache.
++  int shift = internal::page_characteristics.shift.load(std::memory_order_relaxed);
++  if (UNLIKELY(shift == 0)) {
++    shift = __builtin_ctz((int)PageAllocationGranularity());
++    internal::page_characteristics.shift.store(shift, std::memory_order_relaxed);
++  }
++  return shift;
+ #else
+   return 12;  // 4kB
+ #endif
+@@ -61,6 +99,15 @@ PageAllocationGranularity() {
+   // This is literally equivalent to |1 << PageAllocationGranularityShift()|
+   // below, but was separated out for OS_APPLE to avoid << on a non-constexpr.
+   return vm_page_size;
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb, 16kb, and 64kb page sizes. Retrieve from or
++  // initialize cache.
++  int size = internal::page_characteristics.size.load(std::memory_order_relaxed);
++  if (UNLIKELY(size == 0)) {
++    size = getpagesize();
++    internal::page_characteristics.size.store(size, std::memory_order_relaxed);
++  }
++  return size;
+ #else
+   return 1ULL << PageAllocationGranularityShift();
+ #endif
+@@ -90,7 +137,8 @@ SystemPageShift() {
+ 
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ SystemPageSize() {
+-#if defined(OS_APPLE) && defined(ARCH_CPU_64_BITS)
++#if (defined(OS_APPLE) && defined(ARCH_CPU_64_BITS)) || \
++    (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+   // This is literally equivalent to |1 << SystemPageShift()| below, but was
+   // separated out for 64-bit OS_APPLE to avoid << on a non-constexpr.
+   return PageAllocationGranularity();
+diff --git a/chromium/base/allocator/partition_allocator/partition_address_space.cc b/chromium/base/allocator/partition_allocator/partition_address_space.cc
+index ee6294d8f55..3c9e4f47d4c 100644
+--- a/chromium/base/allocator/partition_allocator/partition_address_space.cc
++++ b/chromium/base/allocator/partition_allocator/partition_address_space.cc
+@@ -97,6 +97,12 @@ void PartitionAddressSpace::UninitForTesting() {
+   internal::AddressPoolManager::GetInstance()->ResetForTesting();
+ }
+ 
++#if defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
++PageCharacteristics page_characteristics;
++
++#endif  // defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
+ #endif  // defined(PA_HAS_64_BITS_POINTERS)
+ 
+ }  // namespace internal
+diff --git a/chromium/base/allocator/partition_allocator/partition_alloc_constants.h b/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
+index 1eeac4993a5..61bfc4f4b95 100644
+--- a/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
++++ b/chromium/base/allocator/partition_allocator/partition_alloc_constants.h
+@@ -47,10 +47,11 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PartitionPageShift() {
+   return 18;  // 256 KiB
+ }
+-#elif defined(OS_APPLE) && defined(ARCH_CPU_64_BITS)
++#elif (defined(OS_APPLE) && defined(ARCH_CPU_64_BITS)) || \
++    (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PartitionPageShift() {
+-  return vm_page_shift + 2;
++  return PageAllocationGranularityShift() + 2;
+ }
+ #else
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+diff --git a/chromium/base/allocator/partition_allocator/partition_root.cc b/chromium/base/allocator/partition_allocator/partition_root.cc
+index 37a190f371d..a268c74f62d 100644
+--- a/chromium/base/allocator/partition_allocator/partition_root.cc
++++ b/chromium/base/allocator/partition_allocator/partition_root.cc
+@@ -182,7 +182,7 @@ static size_t PartitionPurgeSlotSpan(
+   constexpr size_t kMaxSlotCount =
+       (PartitionPageSize() * kMaxPartitionPagesPerRegularSlotSpan) /
+       SystemPageSize();
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+   // It's better for slot_usage to be stack-allocated and fixed-size, which
+   // demands that its size be constexpr. On OS_APPLE, PartitionPageSize() is
+   // always SystemPageSize() << 2, so regardless of what the run time page size
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
+index 28c8271fd68..3957e0cdf76 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/address_space_randomization.h
+@@ -120,6 +120,21 @@ AslrMask(uintptr_t bits) {
+         return AslrAddress(0x20000000ULL);
+       }
+ 
++      #elif defined(OS_LINUX)
++
++      // Linux on arm64 can use 39, 42, 48, or 52-bit user space, depending on
++      // page size and number of levels of translation pages used. We use
++      // 39-bit as base as all setups should support this, lowered to 38-bit
++      // as ASLROffset() could cause a carry.
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLRMask() {
++        return AslrMask(38);
++      }
++      PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE uintptr_t
++      ASLROffset() {
++        return AslrAddress(0x1000000000ULL);
++      }
++
+       #else
+ 
+       // ARM64 on Linux has 39-bit user space. Use 38 bits since kASLROffset
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
+index e1cf290a66f..c5386a7c564 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator.cc
+@@ -255,5 +255,13 @@ uint32_t GetAllocPageErrorCode() {
+   return s_allocPageErrorCode;
+ }
+ 
++#if defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
++namespace internal {
++PageCharacteristics page_characteristics;
++}
++
++#endif  // defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++
+ }  // namespace base
+ }  // namespace pdfium
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
+index fdc65ac47b7..f826308839d 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/page_allocator_constants.h
+@@ -24,6 +24,31 @@
+ // elimination.
+ #define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
+ 
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++// This should work for all POSIX (if needed), but currently all other
++// supported OS/architecture combinations use either hard-coded values
++// (such as x86) or have means to determine these values without needing
++// atomics (such as macOS on arm64).
++
++// Page allocator constants are run-time constant
++#define PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR __attribute__((const))
++
++#include <unistd.h>
++#include <atomic>
++
++namespace pdfium::base::internal {
++
++// Holds the current page size and shift, where size = 1 << shift
++// Use PageAllocationGranularity(), PageAllocationGranularityShift()
++// to initialize and retrieve these values safely.
++struct PageCharacteristics {
++  std::atomic<int> size;
++  std::atomic<int> shift;
++};
++extern PageCharacteristics page_characteristics;
++
++}  // namespace base::internal
++
+ #else
+ 
+ // When defined, page size constants are fixed at compile time. When not
+@@ -37,11 +62,18 @@
+ #endif
+ 
+ namespace pdfium {
++
++namespace base {
++// Forward declaration, implementation below
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
++PageAllocationGranularity();
++}
++
+ namespace {
+ 
+ #if !defined(OS_APPLE)
+ 
+-constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
++PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int PageAllocationGranularityShift() {
+ #if defined(OS_WIN) || defined(ARCH_CPU_PPC64)
+   // Modern ppc64 systems support 4kB (shift = 12) and 64kB (shift = 16) page
+   // sizes.  Since 64kB is the de facto standard on the platform and binaries
+@@ -50,6 +82,15 @@ constexpr ALWAYS_INLINE int PageAllocationGranularityShift() {
+   return 16;  // 64kB
+ #elif defined(_MIPS_ARCH_LOONGSON)
+   return 14;  // 16kB
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb (shift = 12), 16kb (shift = 14), and 64kb (shift = 16)
++  // page sizes. Retrieve from or initialize cache.
++  int shift = base::internal::page_characteristics.shift.load(std::memory_order_relaxed);
++  if (UNLIKELY(shift == 0)) {
++    shift = __builtin_ctz((int)base::PageAllocationGranularity());
++    base::internal::page_characteristics.shift.store(shift, std::memory_order_relaxed);
++  }
++  return shift;
+ #else
+   return 12;  // 4kB
+ #endif
+@@ -65,6 +106,15 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PageAllocationGranularity() {
+ #if defined(OS_APPLE)
+   return vm_page_size;
++#elif defined(OS_LINUX) && defined(ARCH_CPU_ARM64)
++  // arm64 supports 4kb, 16kb, and 64kb page sizes. Retrieve from or
++  // initialize cache.
++  int size = internal::page_characteristics.size.load(std::memory_order_relaxed);
++  if (UNLIKELY(size == 0)) {
++    size = getpagesize();
++    internal::page_characteristics.size.store(size, std::memory_order_relaxed);
++  }
++  return size;
+ #else
+   return 1ULL << PageAllocationGranularityShift();
+ #endif
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
+index 2e5e87fa7e6..89b9f6217a6 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc.cc
+@@ -486,7 +486,7 @@ static size_t PartitionPurgePage(internal::PartitionPage* page, bool discard) {
+ #if defined(PAGE_ALLOCATOR_CONSTANTS_ARE_CONSTEXPR)
+   constexpr size_t kMaxSlotCount =
+       (PartitionPageSize() * kMaxPartitionPagesPerSlotSpan) / SystemPageSize();
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+   // It's better for slot_usage to be stack-allocated and fixed-size, which
+   // demands that its size be constexpr. On OS_APPLE, PartitionPageSize() is
+   // always SystemPageSize() << 2, so regardless of what the run time page size
+diff --git a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
+index e3bcf5a9933..1dd3d429f69 100644
+--- a/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
++++ b/chromium/third_party/pdfium/third_party/base/allocator/partition_allocator/partition_alloc_constants.h
+@@ -49,10 +49,11 @@ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+   return 18;  // 256 KiB
+ }
+-#elif defined(OS_APPLE)
++#elif defined(OS_APPLE) || \
++    (defined(OS_LINUX) && defined(ARCH_CPU_ARM64))
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+ PartitionPageShift() {
+-  return vm_page_shift + 2;
++  return PageAllocationGranularityShift() + 2;
+ }
+ #else
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE int
+-- 
+2.37.1
+


### PR DESCRIPTION
I was not able to find other backport of the chromium patch for qt5-webengine, qt6-webengine is similarly affected but I've not done the backport for that yet.

I'll try to push upstream but I'm not sure how long that'll take (either archlinuxarm or qt). I have a local build that has gone passed where this patch is used but isn't finished just yet (running -j2 since there's OOM on mba if there are too much parallel build...). I also put a [similar package in archlinuxcn](https://github.com/archlinuxcn/repo/tree/a083bc215e5659531d8500f1d54940e2729f1480/alarmcn/qt5-webengine-16k) and the auto build should start around 0100 CST (in an hour an a half).

@Chainfire for the backport.