### PR TITLE
libinput: Add a patch to disable the palm exclusion zones

### DIFF
--- a/libinput/PKGBUILD
+++ b/libinput/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=libinput
 pkgver=1.22.0
-pkgrel=1.1
+pkgrel=1.2
 pkgdesc="Input device management and event handling library"
 url="https://gitlab.freedesktop.org/libinput"
 arch=(x86_64)
@@ -15,13 +15,16 @@ optdepends=('gtk4: libinput debug-gui'
             'python-libevdev: libinput measure')
 options=(debug)
 source=(https://gitlab.freedesktop.org/libinput/libinput/-/archive/$pkgver/$pkgname-$pkgver.tar.bz2
-	0001-quirks-Add-Apple-MTP-touchpad-quirk.patch)
+	0001-quirks-Add-Apple-MTP-touchpad-quirk.patch
+	no-palm-exclusion-zones.patch)
 sha256sums=('b9204a860b4f6f9b2587c484f67a21fbdedd01a97db1f983b0b51cb7bdd428aa'
-            'c021958e9fab4dab2572311b56eabdc14088af077978e9023a9ca9bbe8b2b90a')
+            'c021958e9fab4dab2572311b56eabdc14088af077978e9023a9ca9bbe8b2b90a'
+            'd38aa046d680677e55a05f92d9f77b66152a4fed3e42bf10f38cd11447205d7b')
 #validpgpkeys=('3C2C43D9447D5938EF4551EBE23B7E70B467F0BF') # Peter Hutterer (Who-T) <office@who-t.net>
 
 build() {
   ( cd $pkgname-$pkgver && patch -p1 -i ../0001-quirks-Add-Apple-MTP-touchpad-quirk.patch )
+  ( cd $pkgname-$pkgver && patch -p1 -i ../no-palm-exclusion-zones.patch )
 
   arch-meson $pkgname-$pkgver build \
     -D udev-dir=/usr/lib/udev \

--- a/libinput/no-palm-exclusion-zones.patch
+++ b/libinput/no-palm-exclusion-zones.patch
@@ -1,0 +1,15 @@
+diff --git a/src/evdev-mt-touchpad.c b/src/evdev-mt-touchpad.c
+index ea9c8f1e..019ed115 100644
+--- a/src/evdev-mt-touchpad.c
++++ b/src/evdev-mt-touchpad.c
+@@ -3458,8 +3458,8 @@ tp_init_palmdetect(struct tp_dispatch *tp,
+ 				    ABS_MT_TOOL_TYPE))
+ 		tp->palm.use_mt_tool = true;
+ 
+-	if (!tp_is_tablet(device))
+-		tp_init_palmdetect_edge(tp, device);
++/*	if (!tp_is_tablet(device))
++		tp_init_palmdetect_edge(tp, device); */
+ 	tp_init_palmdetect_pressure(tp, device);
+ 	tp_init_palmdetect_size(tp, device);
+ }


### PR DESCRIPTION
This fixes the really annoying cursor freeze issue on the 16" MBP at the very least. See https://gitlab.freedesktop.org/libinput/libinput/-/issues/433 for more details

I've had this patch locally for several months and linked it on `#asahi` ([irc log](https://oftc.irclog.whitequark.org/asahi/2022-08-08#31181820;)). At the time I didn't get any follow up to `I can send a PR to https://github.com/AsahiLinux/PKGBUILDs if you want too` but given there is now already a patch for libinput on this repository it seems easier to add one more patch.

If you want me to have this patch linked to a PR upstream I'm not sure i have the time for that and i have no idea what the best course of action for all devices supported by libinput. Given the base issue is 2 years old and touches too many devices it feels like a lost cause tbh.