### PR TITLE
Let linux-asahi-edge depend on the exact same version of linux-asahi

### DIFF
--- a/linux-asahi/PKGBUILD
+++ b/linux-asahi/PKGBUILD
@@ -95,7 +95,7 @@ build() {
 
 _package_kernel() {
   pkgdesc="The $pkgdesc kernel and modules"
-  depends=(coreutils kmod initramfs "m1n1>=$_m1n1_version")
+  depends=(coreutils kmod initramfs $2 "m1n1>=$_m1n1_version")
   optdepends=('crda: to set the correct wireless channels of your country'
               'linux-firmware: firmware images needed for some devices')
   provides=(WIREGUARD-MODULE linux=${pkgver})
@@ -131,7 +131,7 @@ _package() {
 _package-edge() {
   cd $_srcname
   export O="$PWD/build/edge"
-  _package_kernel "$pkgbase-edge"
+  _package_kernel "$pkgbase-edge" "$pkgbase=$pkgver"
 }
 
 _package-headers() {


### PR DESCRIPTION
Should prevent out of sync updates of both packages.