### PR TITLE
Add python-packaging to mesa-asahi-edge's makedepends

### DIFF
--- a/mesa-asahi-edge/PKGBUILD
+++ b/mesa-asahi-edge/PKGBUILD
@@ -22,7 +22,7 @@ arch=('aarch64')
 makedepends=('python-mako' 'libxml2' 'libx11' 'xorgproto' 'libdrm' 'libxshmfence' 'libxxf86vm'
              'libxdamage' 'libvdpau' 'libva' 'wayland' 'wayland-protocols' 'zstd' 'elfutils' 'llvm'
              'libomxil-bellagio' 'libclc' 'clang' 'libglvnd' 'libunwind' 'lm_sensors' 'libxrandr'
-             'systemd' 'valgrind' 'glslang' 'vulkan-icd-loader' 'directx-headers' 'cmake' 'meson')
+             'systemd' 'valgrind' 'glslang' 'vulkan-icd-loader' 'directx-headers' 'cmake' 'meson' 'python-packaging')
 url="https://www.mesa3d.org/"
 license=('custom')
 options=('debug' '!lto')


### PR DESCRIPTION
It seems `makepkg` fails on mesa-asahi-edge with the following error:
```
...
Program python3 found: YES (/usr/bin/python3)

mesa-asahi-20230904/meson.build:876:2: ERROR: Problem encountered: Python (3.x) mako module >= 0.8.0 required to build mesa.
```

https://gitlab.freedesktop.org/asahi/mesa/-/blob/asahi-20230904/meson.build?ref_type=tags#L867-L877 requires  `distutils`,  but newer Python (>= 3.12) doesn't have `distutils` due to [PEP 632](https://peps.python.org/pep-0632):

> ```meson
> prog_python = import('python').find_installation('python3')
> has_mako = run_command(
>   prog_python, '-c',
>   '''
> from distutils.version import StrictVersion
> import mako
> assert StrictVersion(mako.__version__) >= StrictVersion("0.8.0")
>   ''', check: false)
> if has_mako.returncode() != 0
>   error('Python (3.x) mako module >= 0.8.0 required to build mesa.')
> endif
> ```

This can be fixed to use `packaging` ([`python-packaging` in Arch](https://archlinux.org/packages/extra/any/python-packaging/)) as PEP 632 says:
>  - `distutils.version` — use the packaging package